### PR TITLE
fix: open preview when provisioning completes

### DIFF
--- a/apps/hatchway/src/components/PreviewPanel.tsx
+++ b/apps/hatchway/src/components/PreviewPanel.tsx
@@ -50,7 +50,7 @@ export default function PreviewPanel({
   onSelectionModeChange,
   hideControls = false,
 }: PreviewPanelProps) {
-  const { projects, refetch } = useProjects();
+  const { projects, refetch, updateProject } = useProjects();
   const [key, setKey] = useState(0);
   const [cacheBust, setCacheBust] = useState(0); // For forcing iframe reload
   const [internalSelectionMode, setInternalSelectionMode] = useState(false);
@@ -70,11 +70,7 @@ export default function PreviewPanel({
   const lastPreviewUrlRef = useRef<string>(''); // Track last working preview URL to keep iframe visible during follow-up builds
 
   // Find the current project
-  const project = projects.find(p => p.slug === selectedProject);
-  const [liveProject, setLiveProject] = useState(project);
-
-  // Use live project data if available (from SSE), otherwise fall back to context
-  const currentProject = liveProject || project;
+  const currentProject = projects.find(p => p.slug === selectedProject);
 
   // Port comes from database (pre-allocated in start route)
   const actualPort = currentProject?.devServerPort;
@@ -102,13 +98,12 @@ export default function PreviewPanel({
 
   // Real-time status updates via SSE
   useEffect(() => {
-    if (!project?.id) {
-      setLiveProject(undefined);
+    if (!currentProject?.id) {
       setIsSSEConnected(false);
       return;
     }
 
-    const eventSource = new EventSource(`/api/projects/${project.id}/status-stream`);
+    const eventSource = new EventSource(`/api/projects/${currentProject.id}/status-stream`);
 
     eventSource.onopen = () => {
       setIsSSEConnected(true);
@@ -122,7 +117,7 @@ export default function PreviewPanel({
       try {
         const data = JSON.parse(event.data);
         if (data.type === 'status-update' && data.project) {
-          setLiveProject(data.project);
+          updateProject(data.project);
         }
       } catch (err) {
         console.error('Failed to parse SSE status event:', err);
@@ -132,21 +127,23 @@ export default function PreviewPanel({
     eventSource.onerror = () => {
       setIsSSEConnected(false);
       sseFailureCountRef.current++;
-      eventSource.close();
+      // Keep the EventSource open: the browser reconnects automatically and
+      // the endpoint sends the current full project state on every connection.
     };
 
     return () => {
       setIsSSEConnected(false);
       eventSource.close();
     };
-  }, [project?.id]);
+  }, [currentProject?.id, updateProject]);
 
   // Fallback polling ONLY when SSE fails: Poll during active operations
   useEffect(() => {
-    // Only poll if SSE has failed multiple times (not just temporarily disconnected)
-    if (isSSEConnected || sseFailureCountRef.current < 2) return;
+    // Poll only as a fallback while an operation is active. EventSource will
+    // continue attempting to reconnect in parallel.
+    if (isSSEConnected || sseFailureCountRef.current < 1) return;
 
-    const shouldPoll = isStartingServer || currentProject?.devServerStatus === 'starting';
+    const shouldPoll = isBuildActive || isStartingServer || currentProject?.devServerStatus === 'starting';
 
     if (!shouldPoll) return;
 
@@ -157,7 +154,7 @@ export default function PreviewPanel({
     return () => {
       clearInterval(interval);
     };
-  }, [isSSEConnected, isStartingServer, currentProject?.devServerStatus, refetch]);
+  }, [isSSEConnected, isBuildActive, isStartingServer, currentProject?.devServerStatus, refetch]);
 
   // Force refetch after stop completes (if SSE missed the event)
   useEffect(() => {

--- a/apps/hatchway/src/contexts/ProjectContext.tsx
+++ b/apps/hatchway/src/contexts/ProjectContext.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useCallback, useContext, useState, ReactNode } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useProjectsList, useProjectFiles, type Project as ProjectType, type FileNode as FileNodeType } from '@/queries/projects';
 import { useRunnerStatus } from '@/queries/runner';
+import { mergeProjectUpdate } from '@/lib/project-cache';
 
 // Re-export types for backward compatibility
 export type Project = ProjectType;
@@ -15,12 +17,14 @@ interface ProjectContextType {
   refetch: () => void;
   runnerOnline: boolean | null;
   setActiveProjectId: (id: string | null) => void;
+  updateProject: (project: Project) => void;
 }
 
 const ProjectContext = createContext<ProjectContextType | undefined>(undefined);
 
 export function ProjectProvider({ children }: { children: ReactNode }) {
   const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
   // Use TanStack Query hooks
   const projectsQuery = useProjectsList();
@@ -41,9 +45,21 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  // Status-stream updates and query refetches must feed the same canonical
+  // project list. Keeping a second component-local project snapshot can leave
+  // the preview body on stale provisioning state while the browser chrome has
+  // already received the live URL.
+  const updateProject = useCallback((project: Project) => {
+    queryClient.setQueryData<{ projects: Project[] }>(['projects'], (current) => {
+      if (!current) return current;
+      const projects = mergeProjectUpdate(current.projects, project);
+      return projects === current.projects ? current : { ...current, projects };
+    });
+  }, [queryClient]);
+
   return (
     <ProjectContext.Provider
-      value={{ projects, files, isLoading, refetch, runnerOnline, setActiveProjectId }}
+      value={{ projects, files, isLoading, refetch, runnerOnline, setActiveProjectId, updateProject }}
     >
       {children}
     </ProjectContext.Provider>

--- a/apps/hatchway/src/lib/project-cache.test.ts
+++ b/apps/hatchway/src/lib/project-cache.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mergeProjectUpdate } from './project-cache';
+
+test('applies a ready preview update to the canonical project list', () => {
+  const projects = [{
+    id: 'project-1',
+    name: 'Example',
+    status: 'in_progress',
+    devServerStatus: 'starting',
+    tunnelUrl: null as string | null,
+  }];
+
+  const updated = mergeProjectUpdate(projects, {
+    ...projects[0],
+    status: 'completed',
+    devServerStatus: 'running',
+    tunnelUrl: 'https://example.railgate.test',
+  });
+
+  assert.equal(updated[0].status, 'completed');
+  assert.equal(updated[0].devServerStatus, 'running');
+  assert.equal(updated[0].tunnelUrl, 'https://example.railgate.test');
+  assert.notEqual(updated, projects);
+});
+
+test('ignores updates for projects outside the cached list', () => {
+  const projects = [{ id: 'project-1', status: 'in_progress' }];
+  const updated = mergeProjectUpdate(projects, { id: 'project-2', status: 'completed' });
+
+  assert.equal(updated, projects);
+});

--- a/apps/hatchway/src/lib/project-cache.ts
+++ b/apps/hatchway/src/lib/project-cache.ts
@@ -1,0 +1,12 @@
+/** Merge a live project update without replacing the surrounding project list. */
+export function mergeProjectUpdate<T extends { id: string }>(
+  projects: T[],
+  project: T,
+): T[] {
+  const projectIndex = projects.findIndex((candidate) => candidate.id === project.id);
+  if (projectIndex === -1) return projects;
+
+  const updatedProjects = [...projects];
+  updatedProjects[projectIndex] = { ...updatedProjects[projectIndex], ...project };
+  return updatedProjects;
+}


### PR DESCRIPTION
## Summary

- write status-stream project updates into the canonical React Query project cache
- remove the stale component-local project snapshot that could keep the loading game visible
- preserve native EventSource reconnection and poll active builds as a fallback
- add regression coverage for the provisioning-to-ready project transition

## Release

This follows the default patch release path. After merge, auto-release.yml will run the full quality gate, bump 0.51.22 to 0.51.23, create tag v0.51.23, publish the CLI, and create the GitHub release.

## Validation

- pnpm --filter hatchway exec tsx --test src/lib/project-cache.test.ts
- pnpm --filter hatchway build
- git diff --check