### PR TITLE
feat: make sandbox the default execution mode

### DIFF
--- a/apps/hatchway/src/app/api/projects/[id]/build/route.ts
+++ b/apps/hatchway/src/app/api/projects/[id]/build/route.ts
@@ -128,7 +128,7 @@ export async function POST(
       });
     }
 
-    // EXECUTION MODE: 'local' (default) and 'sandbox' both build on the
+    // EXECUTION MODE: 'sandbox' (default) and 'local' both build on the
     // connected local runner (local Claude Code, user's subscription). In
     // 'sandbox' mode the runner then ships the built workspace to a
     // backend-managed Railway sandbox via POST /api/projects/[id]/sandbox/sync
@@ -136,10 +136,9 @@ export async function POST(
     // executionMode is chosen ONCE, on the initial build, and locked for the
     // life of the project. Follow-up builds (enhancement / focused-edit) must
     // NOT change it — the client's global execution-mode context can carry a
-    // stale/default 'local', and honoring it here would downgrade a sandbox
-    // project to local, breaking the post-build re-sync AND stop/restart
-    // (which then runs a local dev server and shows a localhost URL).
-    const persistedMode = (project.executionMode as 'local' | 'sandbox' | null) ?? 'local';
+    // stale value, and honoring it here would switch a locked project mode,
+    // breaking sandbox re-sync or local restart.
+    const persistedMode = (project.executionMode as 'local' | 'sandbox' | null) ?? 'sandbox';
     const executionMode = body.operationType === 'initial-build'
       ? (body.executionMode ?? persistedMode)
       : persistedMode;

--- a/apps/hatchway/src/app/api/projects/[id]/start/route.ts
+++ b/apps/hatchway/src/app/api/projects/[id]/start/route.ts
@@ -72,7 +72,7 @@ export async function POST(
       // Sandbox previews each run on their own isolated host, so ports can never
       // collide — use a fixed port and skip allocation/conflict checks. Local
       // mode allocates a non-conflicting port on the host.
-      const isSandboxMode = ((proj.executionMode as string | null) ?? 'local') === 'sandbox';
+      const isSandboxMode = ((proj.executionMode as string | null) ?? 'sandbox') === 'sandbox';
       let portInfo: { port: number; framework: Parameters<typeof buildEnvForFramework>[0] };
       if (isSandboxMode) {
         portInfo = {
@@ -143,7 +143,7 @@ export async function POST(
           // Restart on the same path the project was built on. Without this the
           // runner defaults to 'local' and a sandbox project comes back on
           // localhost instead of re-syncing to its Railway sandbox.
-          executionMode: (proj.executionMode as 'local' | 'sandbox' | null) ?? 'local',
+          executionMode: (proj.executionMode as 'local' | 'sandbox' | null) ?? 'sandbox',
         },
       };
 

--- a/apps/hatchway/src/app/api/projects/create-from-analysis/route.ts
+++ b/apps/hatchway/src/app/api/projects/create-from-analysis/route.ts
@@ -92,6 +92,7 @@ export async function POST(request: Request) {
         tags: tags || null,
         userId: userId,
         runnerId: runnerId || null,
+        executionMode: body.executionMode === 'local' ? 'local' : 'sandbox',
       }).returning();
 
       const initialContent = messageParts && messageParts.length > 0

--- a/apps/hatchway/src/app/api/projects/route.ts
+++ b/apps/hatchway/src/app/api/projects/route.ts
@@ -171,6 +171,7 @@ export async function POST(request: Request) {
       originalPrompt: prompt,
       tags: tags || null, // Store tags if provided
       userId: userId, // Associate with authenticated user (null in local mode)
+      executionMode: 'sandbox',
     }).returning();
 
     console.log(`✅ Project created: ${project.id}`);

--- a/apps/hatchway/src/app/api/runner/events/route.ts
+++ b/apps/hatchway/src/app/api/runner/events/route.ts
@@ -664,7 +664,7 @@ IMPORTANT:
               //   preview keeps serving the previous build.
               // ============================================================
               const serverAlreadyRunning = updated.devServerStatus === 'running';
-              const isSandboxMode = ((updated.executionMode as string | null) ?? 'local') === 'sandbox';
+              const isSandboxMode = ((updated.executionMode as string | null) ?? 'sandbox') === 'sandbox';
               if (updated.runCommand && updated.path && (!serverAlreadyRunning || isSandboxMode)) {
                 console.log(`[events] 🚀 ${serverAlreadyRunning ? 'Re-syncing sandbox' : 'Auto-starting dev server'} for completed build...`);
 
@@ -727,7 +727,7 @@ IMPORTANT:
                         workingDirectory: updated.path,
                         env: portEnv,
                         preferredPort: port,
-                        executionMode: (updated.executionMode as 'local' | 'sandbox' | null) ?? 'local',
+                        executionMode: (updated.executionMode as 'local' | 'sandbox' | null) ?? 'sandbox',
                       },
                     };
 

--- a/apps/hatchway/src/app/page.tsx
+++ b/apps/hatchway/src/app/page.tsx
@@ -673,11 +673,25 @@ function HomeContent() {
   } = useAgent();
   const { executionMode, setExecutionMode } = useExecutionMode();
 
-  // Seed the execution-mode selector from the opened project's saved mode (per-project persistence)
+  // Seed the selector from the opened project's locked mode without writing
+  // localStorage (opening a local project must not make Local the default for
+  // the next new project). On the landing page, restore the user preference /
+  // sandbox default.
   useEffect(() => {
     const mode = (currentProject as { executionMode?: string } | null | undefined)?.executionMode;
     if (mode === 'local' || mode === 'sandbox') {
-      setExecutionMode(mode);
+      setExecutionMode(mode, { persist: false });
+      return;
+    }
+    if (!currentProject) {
+      if (typeof window !== 'undefined') {
+        const stored = window.localStorage.getItem('hatchway.executionMode');
+        if (stored === 'local' || stored === 'sandbox') {
+          setExecutionMode(stored, { persist: false });
+          return;
+        }
+      }
+      setExecutionMode('sandbox', { persist: false });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentProject?.id]);
@@ -1560,7 +1574,7 @@ function HomeContent() {
           requestMessageId,
           buildId: existingBuildId,
           runnerId: effectiveRunnerId,
-          executionMode, // 'local' (default) or 'sandbox' (provisions a Railway sandbox runner)
+          executionMode, // 'sandbox' (default) or 'local'
           agent: effectiveAgent,
           claudeModel: effectiveClaudeModel,
           codexThreadId: generationStateRef.current?.codex?.threadId, // For Codex thread resumption
@@ -2314,6 +2328,7 @@ function HomeContent() {
             runnerId: effectiveRunnerId,
             claudeModel: effectiveClaudeModel,
             tags: serializeTags(appliedTags),
+            executionMode,
           }),
         });
 

--- a/apps/hatchway/src/components/ExecutionModeSelector.tsx
+++ b/apps/hatchway/src/components/ExecutionModeSelector.tsx
@@ -12,8 +12,8 @@ interface ExecutionModeSelectorProps {
 }
 
 const OPTIONS: { value: ExecutionMode; label: string; icon: typeof Monitor; title: string }[] = [
-  { value: 'local', label: 'Local', icon: Monitor, title: 'Run the build on a connected runner' },
   { value: 'sandbox', label: 'Sandbox', icon: Boxes, title: 'Run the build in an ephemeral Railway sandbox' },
+  { value: 'local', label: 'Local', icon: Monitor, title: 'Run the build on a connected runner' },
 ];
 
 export function ExecutionModeSelector({ onChange, disabled, className }: ExecutionModeSelectorProps) {
@@ -21,7 +21,7 @@ export function ExecutionModeSelector({ onChange, disabled, className }: Executi
 
   const select = (mode: ExecutionMode) => {
     if (disabled || mode === executionMode) return;
-    setExecutionMode(mode);
+    setExecutionMode(mode, { persist: true });
     onChange?.(mode);
   };
 

--- a/apps/hatchway/src/components/PreviewControls.tsx
+++ b/apps/hatchway/src/components/PreviewControls.tsx
@@ -44,7 +44,7 @@ export function PreviewControls({
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const currentProject = projects.find(p => p.slug === selectedProject);
-  const isSandboxProject = (currentProject?.executionMode ?? 'local') === 'sandbox';
+  const isSandboxProject = (currentProject?.executionMode ?? 'sandbox') === 'sandbox';
   const previewUrl = verifiedTunnelUrl || currentProject?.tunnelUrl || (actualPort && !isSandboxProject ? `http://localhost:${actualPort}` : null);
 
   const handleCopyUrl = useCallback(() => {

--- a/apps/hatchway/src/components/PreviewPanel.tsx
+++ b/apps/hatchway/src/components/PreviewPanel.tsx
@@ -190,7 +190,7 @@ export default function PreviewPanel({
 
   // Sandbox projects run entirely in a Railway sandbox and are ONLY reachable
   // via the railgate tunnel — there is no local dev server.
-  const isSandboxProject = (currentProject?.executionMode ?? 'local') === 'sandbox';
+  const isSandboxProject = (currentProject?.executionMode ?? 'sandbox') === 'sandbox';
 
   // Show preview when server is running and we can reach it:
   // local frontend, railgate preview URL, or WS proxy

--- a/apps/hatchway/src/components/TabbedPreview.tsx
+++ b/apps/hatchway/src/components/TabbedPreview.tsx
@@ -113,7 +113,7 @@ const TabbedPreview = forwardRef<HTMLDivElement, TabbedPreviewProps>(({
   const actualPort = currentProject?.devServerPort;
   // Sandbox projects are only reachable via the railgate tunnel — never fall
   // back to localhost for them (there is no local dev server).
-  const isSandboxProject = (currentProject?.executionMode ?? 'local') === 'sandbox';
+  const isSandboxProject = (currentProject?.executionMode ?? 'sandbox') === 'sandbox';
   const previewUrl = currentProject ? getProjectPreviewUrl(currentProject) : null;
   const isServerRunning = currentProject?.devServerStatus === 'running';
 

--- a/apps/hatchway/src/contexts/ExecutionModeContext.tsx
+++ b/apps/hatchway/src/contexts/ExecutionModeContext.tsx
@@ -12,14 +12,22 @@ import {
 
 export type ExecutionMode = 'local' | 'sandbox';
 
+/** Default for new projects / landing page when the user has no stored preference. */
 export const DEFAULT_EXECUTION_MODE: ExecutionMode = 'sandbox';
 
 interface ExecutionModeContextValue {
   executionMode: ExecutionMode;
-  setExecutionMode: (mode: ExecutionMode) => void;
+  /**
+   * Update the active mode. When `persist` is true (default), write the user's
+   * preference to localStorage so the next new project uses it. Project-scoped
+   * seeding should pass `persist: false` so opening a local project does not
+   * make sandbox stop being the default for new builds.
+   */
+  setExecutionMode: (mode: ExecutionMode, options?: { persist?: boolean }) => void;
 }
 
-const STORAGE_KEY = 'executionMode';
+// Bumped key so pre-sandbox-default "local" prefs do not stick forever.
+const STORAGE_KEY = 'hatchway.executionMode';
 
 const ExecutionModeContext = createContext<ExecutionModeContextValue | undefined>(undefined);
 
@@ -34,8 +42,9 @@ export function ExecutionModeProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const setExecutionMode = useCallback((mode: ExecutionMode) => {
+  const setExecutionMode = useCallback((mode: ExecutionMode, options?: { persist?: boolean }) => {
     setExecutionModeState(mode);
+    if (options?.persist === false) return;
     if (typeof window !== 'undefined') {
       window.localStorage.setItem(STORAGE_KEY, mode);
     }

--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -1679,7 +1679,7 @@ export async function startRunner(options: RunnerOptions = {}) {
             workingDirectory,
             env = {},
             preferredPort,
-            executionMode = 'local',
+            executionMode = 'sandbox',
           } = command.payload;
 
           // Sandbox mode: ship the locally-built workspace to the backend-managed

--- a/packages/agent-core/src/lib/db/schema.ts
+++ b/packages/agent-core/src/lib/db/schema.ts
@@ -152,7 +152,7 @@ export const projects = pgTable('projects', {
   railwayDeploymentStatus: text('railway_deployment_status'), // 'deploying' | 'success' | 'failed' | 'crashed'
   railwayLastDeployedAt: timestamp('railway_last_deployed_at'), // Last successful deployment
   // Execution mode: where builds run for this project
-  executionMode: text('execution_mode').default('local'), // 'local' | 'sandbox'
+  executionMode: text('execution_mode').default('sandbox'), // 'sandbox' (default) | 'local'
   sandboxId: text('sandbox_id'), // Railway sandbox id when executionMode='sandbox' and currently running (warm)
   sandboxStatus: text('sandbox_status'), // 'provisioning' | 'running' | 'stopped' | 'failed'
   sandboxCheckpoint: text('sandbox_checkpoint'), // Railway checkpoint key for this project's saved workspace (restore point)

--- a/packages/agent-core/src/types/build.ts
+++ b/packages/agent-core/src/types/build.ts
@@ -52,7 +52,7 @@ export interface BuildRequest {
   messageParts?: MessagePart[]; // Multi-modal content (text, images, etc.)
   requestMessageId?: string; // User message that explicitly requested this build
   runnerId?: string; // Optional runner ID - falls back to RUNNER_DEFAULT_ID
-  executionMode?: 'local' | 'sandbox'; // Where the build runs (default 'local'); 'sandbox' provisions a Railway sandbox runner
+  executionMode?: 'local' | 'sandbox'; // Where the build runs (default 'sandbox'); 'local' uses a connected runner only
   buildId?: string;
   agent?: AgentId; // Selected coding agent provider (Claude Code, OpenAI Codex, etc.)
   claudeModel?: ClaudeModelId;


### PR DESCRIPTION
## Summary
- Default the Local/Sandbox toggle to **Sandbox** for new projects (UI, create APIs, schema, and server fallbacks).
- Keep the same toggle; only change the default path.
- Opening a local project no longer writes Local into the global preference, so the next new project still defaults to Sandbox.
- Bump the localStorage key so older `local` prefs do not keep forcing Local forever.

## Test plan
- [ ] Fresh browser / cleared storage: landing toggle shows Sandbox selected
- [ ] Submit a new project without changing the toggle → project `executionMode` is `sandbox`
- [ ] Switch toggle to Local, create a project → stays local
- [ ] Open an existing local project, go back home → toggle returns to Sandbox (or last explicit preference), not stuck on Local
- [ ] Existing sandbox projects still lock to sandbox on follow-up builds