### PR TITLE
feat: upgrade default Claude Sonnet to Sonnet 5

### DIFF
--- a/apps/hatchway/src/app/api/projects/[id]/build/route.ts
+++ b/apps/hatchway/src/app/api/projects/[id]/build/route.ts
@@ -111,7 +111,7 @@ export async function POST(
     } else {
       // Fallback to body parameters if no model tag
       claudeModel =
-        agentId === 'claude-code' && (body.claudeModel === 'claude-haiku-4-5' || body.claudeModel === 'claude-sonnet-4-6' || body.claudeModel === 'claude-opus-4-8')
+        agentId === 'claude-code' && (body.claudeModel === 'claude-haiku-4-5' || body.claudeModel === 'claude-sonnet-5' || body.claudeModel === 'claude-opus-4-8')
           ? body.claudeModel
           : DEFAULT_CLAUDE_MODEL_ID;
     }

--- a/apps/hatchway/src/app/page.tsx
+++ b/apps/hatchway/src/app/page.tsx
@@ -711,7 +711,7 @@ function HomeContent() {
   const selectedClaudeModel = claudeModels.find(
     (model) => model.id === selectedClaudeModelId,
   );
-  const selectedClaudeModelLabel = selectedClaudeModel?.label ?? "Claude Sonnet 4.6";
+  const selectedClaudeModelLabel = selectedClaudeModel?.label ?? "Claude Sonnet 5";
 
   const clearDraftRecovery = useCallback(async () => {
     setHasRecoveredDraft(false);

--- a/apps/hatchway/src/contexts/AgentContext.tsx
+++ b/apps/hatchway/src/contexts/AgentContext.tsx
@@ -81,8 +81,16 @@ export function AgentProvider({ children }: { children: ReactNode }) {
     }
 
     const storedClaudeModel = window.localStorage.getItem(CLAUDE_MODEL_STORAGE_KEY);
-    if (storedClaudeModel === 'claude-haiku-4-5' || storedClaudeModel === 'claude-sonnet-4-6' || storedClaudeModel === 'claude-opus-4-8') {
+    if (
+      storedClaudeModel === 'claude-haiku-4-5' ||
+      storedClaudeModel === 'claude-sonnet-5' ||
+      storedClaudeModel === 'claude-opus-4-8'
+    ) {
       setSelectedClaudeModelIdState(storedClaudeModel);
+    } else if (storedClaudeModel === 'claude-sonnet-4-6') {
+      // Upgrade saved Sonnet 4.6 preference to Sonnet 5
+      setSelectedClaudeModelIdState('claude-sonnet-5');
+      window.localStorage.setItem(CLAUDE_MODEL_STORAGE_KEY, 'claude-sonnet-5');
     }
   }, []);
 

--- a/apps/hatchway/src/contexts/SDKModeContext.tsx
+++ b/apps/hatchway/src/contexts/SDKModeContext.tsx
@@ -40,7 +40,7 @@ export function getEnabledSDKModes(): SDKMode[] {
 
 // Model arrays for each SDK mode - add new models here as needed
 export const AGENT_SDK_MODELS = [
-  'claude-sonnet-4-6',
+  'claude-sonnet-5',
   'claude-opus-4-8',
   'claude-haiku-4-5',
   'gpt-5.2-codex',

--- a/apps/hatchway/src/lib/model-logos.ts
+++ b/apps/hatchway/src/lib/model-logos.ts
@@ -4,6 +4,7 @@
  */
 export function getModelLogo(modelValue: string): string | null {
   const logoMap: Record<string, string> = {
+    'claude-sonnet-5': '/claude.png',
     'claude-sonnet-4-6': '/claude.png',
     'claude-opus-4-8': '/claude.png',
     'claude-haiku-4-5': '/claude.png',

--- a/apps/hatchway/src/lib/pending-auth-draft.test.ts
+++ b/apps/hatchway/src/lib/pending-auth-draft.test.ts
@@ -19,9 +19,9 @@ function draft(savedAt: number): PendingAuthDraft {
     }],
     project: null,
     buildConfig: {
-      appliedTags: [{ key: 'model', value: 'claude-sonnet-4-6', appliedAt: new Date(savedAt).toISOString() }],
+      appliedTags: [{ key: 'model', value: 'claude-sonnet-5', appliedAt: new Date(savedAt).toISOString() }],
       selectedAgentId: 'claude-code',
-      selectedClaudeModelId: 'claude-sonnet-4-6',
+      selectedClaudeModelId: 'claude-sonnet-5',
       selectedRunnerId: 'runner-1',
       executionMode: 'sandbox',
     },
@@ -33,7 +33,7 @@ test('preserves image payloads larger than sessionStorage quotas', () => {
   const parsed = parsePendingAuthDraft(draft(savedAt), savedAt);
 
   assert.equal(parsed?.images[0].image.length, 6 * 1024 * 1024 + 'data:image/png;base64,'.length);
-  assert.equal(parsed?.buildConfig.appliedTags[0].value, 'claude-sonnet-4-6');
+  assert.equal(parsed?.buildConfig.appliedTags[0].value, 'claude-sonnet-5');
 });
 
 test('rejects expired or malformed recovery records', () => {

--- a/apps/opencode-service/src/index.ts
+++ b/apps/opencode-service/src/index.ts
@@ -38,7 +38,7 @@ async function main() {
       timeout: 30000, // 30 second timeout for server start
       config: {
         // Default model - can be overridden per request
-        model: process.env.OPENCODE_DEFAULT_MODEL || 'anthropic/claude-sonnet-4-6',
+        model: process.env.OPENCODE_DEFAULT_MODEL || 'anthropic/claude-sonnet-5',
       },
     });
     

--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -2319,7 +2319,7 @@ export async function startRunner(options: RunnerOptions = {}) {
         const claudeModelFromPayload = command.payload?.claudeModel;
         const model = agent === 'claude-code' && 
           (claudeModelFromPayload === 'claude-haiku-4-5' || 
-           claudeModelFromPayload === 'claude-sonnet-4-6' || 
+           claudeModelFromPayload === 'claude-sonnet-5' || 
            claudeModelFromPayload === 'claude-opus-4-8')
           ? claudeModelFromPayload
           : DEFAULT_CLAUDE_MODEL_ID;
@@ -2369,7 +2369,7 @@ export async function startRunner(options: RunnerOptions = {}) {
           const claudeModel: ClaudeModelId =
             agent === "claude-code" &&
             (command.payload.claudeModel === "claude-haiku-4-5" ||
-              command.payload.claudeModel === "claude-sonnet-4-6" ||
+              command.payload.claudeModel === "claude-sonnet-5" ||
               command.payload.claudeModel === "claude-opus-4-8")
               ? command.payload.claudeModel
               : DEFAULT_CLAUDE_MODEL_ID;

--- a/apps/runner/src/lib/project-analyzer.ts
+++ b/apps/runner/src/lib/project-analyzer.ts
@@ -28,13 +28,14 @@ import type { RunnerEvent } from '@hatchway/agent-core';
 
 // Map model IDs to Claude Agent SDK model names
 const MODEL_MAP: Record<string, string> = {
-  'claude-haiku-4-5': 'claude-sonnet-4-6', // Haiku 4.5 not yet available, use Sonnet
-  'claude-sonnet-4-6': 'claude-sonnet-4-6',
+  'claude-haiku-4-5': 'claude-haiku-4-5',
+  'claude-sonnet-5': 'claude-sonnet-5',
+  'claude-sonnet-4-6': 'claude-sonnet-5', // upgrade legacy default
   'claude-opus-4-8': 'claude-opus-4-8',
 };
 
 function resolveModelName(modelId: string): string {
-  return MODEL_MAP[modelId] || 'claude-sonnet-4-6';
+  return MODEL_MAP[modelId] || 'claude-sonnet-5';
 }
 
 /**
@@ -394,7 +395,7 @@ export async function analyzeProject(
   commandId: string
 ): Promise<AnalyzeProjectResult> {
   const { prompt, agent, claudeModel, tags } = options;
-  const model = claudeModel || 'claude-sonnet-4-6';
+  const model = claudeModel || 'claude-sonnet-5';
   
   console.log('[project-analyzer] Starting project analysis...');
   console.log(`[project-analyzer] Agent: ${agent}, Model: ${model}`);

--- a/packages/agent-core/src/config/tags.ts
+++ b/packages/agent-core/src/config/tags.ts
@@ -51,12 +51,12 @@ export const TAG_DEFINITIONS: TagDefinition[] = [
     inputType: 'select',
     options: [
       {
-        value: 'claude-sonnet-4-6',
-        label: 'Claude Sonnet 4.6',
-        description: 'Anthropic Claude - Balanced performance and speed',
+        value: 'claude-sonnet-5',
+        label: 'Claude Sonnet 5',
+        description: 'Anthropic Claude - Best balance of speed and intelligence',
         logo: '/claude.png',
         provider: 'claude-code',
-        model: 'claude-sonnet-4-6',
+        model: 'claude-sonnet-5',
         sdk: 'agent'
       },
       {

--- a/packages/agent-core/src/lib/build/engine.ts
+++ b/packages/agent-core/src/lib/build/engine.ts
@@ -227,7 +227,7 @@ async function runBuildPipeline(params: BuildPipelineParams) {
   const { projectId: id, prompt, operationType, context, writer, query, agent, claudeModel } = params;
   const agentId: AgentId = agent ?? DEFAULT_AGENT_ID;
   const resolvedClaudeModel: ClaudeModelId =
-    agentId === 'claude-code' && (claudeModel === 'claude-haiku-4-5' || claudeModel === 'claude-sonnet-4-6' || claudeModel === 'claude-opus-4-8')
+    agentId === 'claude-code' && (claudeModel === 'claude-haiku-4-5' || claudeModel === 'claude-sonnet-5' || claudeModel === 'claude-opus-4-8')
       ? claudeModel
       : DEFAULT_CLAUDE_MODEL_ID;
 

--- a/packages/agent-core/src/types/agent.ts
+++ b/packages/agent-core/src/types/agent.ts
@@ -11,9 +11,10 @@ export type AgentId = 'claude-code' | 'opencode' | 'openai-codex' | 'factory-dro
 export const DEFAULT_AGENT_ID: AgentId = 'claude-code';
 
 // Legacy Claude-specific model IDs (backwards compatibility)
-export type ClaudeModelId = 'claude-haiku-4-5' | 'claude-sonnet-4-6' | 'claude-opus-4-8';
+// Anthropic API ID for Sonnet 5 is `claude-sonnet-5` (dateless alias).
+export type ClaudeModelId = 'claude-haiku-4-5' | 'claude-sonnet-5' | 'claude-opus-4-8';
 
-export const DEFAULT_CLAUDE_MODEL_ID: ClaudeModelId = 'claude-sonnet-4-6';
+export const DEFAULT_CLAUDE_MODEL_ID: ClaudeModelId = 'claude-sonnet-5';
 
 // New OpenCode model format: provider/model
 export type OpenCodeModelId = 
@@ -26,13 +27,15 @@ export type OpenCodeModelId =
   | `openrouter/${string}`
   | string;
 
-export const DEFAULT_OPENCODE_MODEL_ID: OpenCodeModelId = 'anthropic/claude-sonnet-4-6';
+export const DEFAULT_OPENCODE_MODEL_ID: OpenCodeModelId = 'anthropic/claude-sonnet-5';
 
 // Legacy model mapping
 export const LEGACY_MODEL_MAP: Record<string, OpenCodeModelId> = {
   'claude-haiku-4-5': 'anthropic/claude-haiku-4-5',
-  'claude-sonnet-4-6': 'anthropic/claude-sonnet-4-6',
+  'claude-sonnet-5': 'anthropic/claude-sonnet-5',
   'claude-opus-4-8': 'anthropic/claude-opus-4-8',
+  // Upgrade previously-saved Sonnet 4.6 selections to Sonnet 5
+  'claude-sonnet-4-6': 'anthropic/claude-sonnet-5',
   // Legacy aliases — upgrade previously-saved selections to the current model
   'claude-opus-4-6': 'anthropic/claude-opus-4-8',
   'claude-opus-4-6-20251101': 'anthropic/claude-opus-4-8',
@@ -58,7 +61,7 @@ export function parseModelId(modelId: string): { provider: string; model: string
   const [provider, ...modelParts] = normalized.split('/');
   return {
     provider: provider || 'anthropic',
-    model: modelParts.join('/') || 'claude-sonnet-4-6',
+    model: modelParts.join('/') || 'claude-sonnet-5',
   };
 }
 
@@ -75,9 +78,9 @@ export const CLAUDE_MODEL_METADATA: Record<ClaudeModelId, ModelMetadata> = {
     description: 'Fast and efficient Claude model',
     provider: 'anthropic',
   },
-  'claude-sonnet-4-6': {
-    label: 'Claude Sonnet 4.6',
-    description: 'Balanced performance and quality',
+  'claude-sonnet-5': {
+    label: 'Claude Sonnet 5',
+    description: 'Best balance of speed and intelligence',
     provider: 'anthropic',
   },
   'claude-opus-4-8': {
@@ -94,9 +97,9 @@ export const MODEL_METADATA: Record<string, ModelMetadata> = {
     description: 'Fast and efficient',
     provider: 'anthropic',
   },
-  'anthropic/claude-sonnet-4-6': {
-    label: 'Claude Sonnet 4.6',
-    description: 'Balanced performance and quality',
+  'anthropic/claude-sonnet-5': {
+    label: 'Claude Sonnet 5',
+    description: 'Best balance of speed and intelligence',
     provider: 'anthropic',
   },
   'anthropic/claude-opus-4-8': {

--- a/packages/opencode-client/src/types.ts
+++ b/packages/opencode-client/src/types.ts
@@ -19,7 +19,7 @@ export type OpenCodeProvider =
 
 // Common model IDs per provider
 export type AnthropicModelId = 
-  | 'claude-sonnet-4-6'
+  | 'claude-sonnet-5'
   | 'claude-haiku-4-5'
   | 'claude-opus-4-8';
 
@@ -47,7 +47,7 @@ export type OpenCodeModelId =
   | `openrouter/${string}` // Any OpenRouter model
   | string;                // Allow any provider/model combo
 
-export const DEFAULT_OPENCODE_MODEL_ID: OpenCodeModelId = 'anthropic/claude-sonnet-4-6';
+export const DEFAULT_OPENCODE_MODEL_ID: OpenCodeModelId = 'anthropic/claude-sonnet-5';
 
 // Agent types
 export type AgentId = 'opencode' | 'openai-codex';
@@ -61,10 +61,10 @@ export interface ModelMetadata {
 }
 
 export const MODEL_METADATA: Record<string, ModelMetadata> = {
-  'anthropic/claude-sonnet-4-6': {
-    label: 'Claude Sonnet 4.6',
+  'anthropic/claude-sonnet-5': {
+    label: 'Claude Sonnet 5',
     provider: 'anthropic',
-    description: 'Balanced performance and quality',
+    description: 'Best balance of speed and intelligence',
   },
   'anthropic/claude-haiku-4-5': {
     label: 'Claude Haiku 4.5',
@@ -106,7 +106,8 @@ export const MODEL_METADATA: Record<string, ModelMetadata> = {
 // Legacy model mapping for backwards compatibility
 export const LEGACY_MODEL_MAP: Record<string, OpenCodeModelId> = {
   'claude-haiku-4-5': 'anthropic/claude-haiku-4-5',
-  'claude-sonnet-4-6': 'anthropic/claude-sonnet-4-6',
+  'claude-sonnet-5': 'anthropic/claude-sonnet-5',
+  'claude-sonnet-4-6': 'anthropic/claude-sonnet-5',
   'claude-opus-4-8': 'anthropic/claude-opus-4-8',
 };
 
@@ -131,7 +132,7 @@ export function parseModelId(modelId: OpenCodeModelId): { provider: string; mode
   const [provider, ...modelParts] = normalized.split('/');
   return {
     provider: provider || 'anthropic',
-    model: modelParts.join('/') || 'claude-sonnet-4-6',
+    model: modelParts.join('/') || 'claude-sonnet-5',
   };
 }
 


### PR DESCRIPTION
## Summary
- Anthropic Claude Sonnet 5 API ID is `claude-sonnet-5` (per [Models overview](https://platform.claude.com/docs/en/about-claude/models/overview)).
- Replace Hatchway default/option `claude-sonnet-4-6` with `claude-sonnet-5` in agent types, model tags, build validation, runner, and OpenCode defaults.
- Upgrade saved Sonnet 4.6 localStorage/prefs to Sonnet 5 so existing browsers pick up the new default.

## Test plan
- [ ] Model picker shows Claude Sonnet 5 (not 4.6)
- [ ] New build without an explicit model uses `claude-sonnet-5`
- [ ] Tag `@model claude-sonnet-5` works; legacy `claude-sonnet-4-6` maps to Sonnet 5 where applicable
- [ ] Runner accepts and logs `claude-sonnet-5` on start-build