### PR TITLE
feat: persist build metrics for latency inspection

### DIFF
--- a/apps/hatchway/drizzle/0018_add_build_metrics.sql
+++ b/apps/hatchway/drizzle/0018_add_build_metrics.sql
@@ -1,0 +1,51 @@
+CREATE TABLE IF NOT EXISTS "build_metrics" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"project_id" uuid NOT NULL,
+	"session_id" uuid,
+	"build_id" text,
+	"command_id" text,
+	"status" text NOT NULL,
+	"agent" text,
+	"model" text,
+	"total_ms" integer,
+	"orchestration_ms" integer,
+	"agent_ms" integer,
+	"time_to_first_chunk_ms" integer,
+	"runner_overhead_ms" integer,
+	"total_tokens" integer,
+	"input_tokens" integer,
+	"output_tokens" integer,
+	"cache_read_input_tokens" integer,
+	"cache_creation_input_tokens" integer,
+	"num_turns" integer,
+	"total_cost_usd" text,
+	"dependency_install_total_ms" integer,
+	"dependency_install_calls" integer,
+	"modified_file_count" integer,
+	"completed_todo_count" integer,
+	"error" text,
+	"metrics" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "build_metrics" ADD CONSTRAINT "build_metrics_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "build_metrics" ADD CONSTRAINT "build_metrics_session_id_generation_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."generation_sessions"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "build_metrics_project_id_idx" ON "build_metrics" USING btree ("project_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "build_metrics_session_id_idx" ON "build_metrics" USING btree ("session_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "build_metrics_build_id_idx" ON "build_metrics" USING btree ("build_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "build_metrics_created_at_idx" ON "build_metrics" USING btree ("created_at");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "build_metrics_command_id_unique" ON "build_metrics" USING btree ("command_id");

--- a/apps/hatchway/drizzle/meta/_journal.json
+++ b/apps/hatchway/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1783756942000,
       "tag": "0017_add_generation_request_message",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1784304000000,
+      "tag": "0018_add_build_metrics",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hatchway/server.ts
+++ b/apps/hatchway/server.ts
@@ -27,12 +27,81 @@ import next from 'next';
 import { buildWebSocketServer, db } from '@hatchway/agent-core';
 import { onRunnerStatusChange } from '@hatchway/agent-core/lib/runner/broker-state';
 import { projects } from '@hatchway/agent-core/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { projectEvents } from './src/lib/project-events';
 import { enrichProjectWithRunnerStatus } from './src/lib/runner-utils';
 import { getAuth } from './src/lib/auth';
 import { isProjectAccessibleBy } from './src/lib/auth-helpers';
 import { fromNodeHeaders } from 'better-auth/node';
+
+/**
+ * Idempotent schema ensure for build metrics persistence.
+ * Prefer this over full drizzle migrate on boot because production DBs may
+ * predate a complete migration journal.
+ */
+async function ensureBuildMetricsTable(): Promise<void> {
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "build_metrics" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+      "project_id" uuid NOT NULL,
+      "session_id" uuid,
+      "build_id" text,
+      "command_id" text,
+      "status" text NOT NULL,
+      "agent" text,
+      "model" text,
+      "total_ms" integer,
+      "orchestration_ms" integer,
+      "agent_ms" integer,
+      "time_to_first_chunk_ms" integer,
+      "runner_overhead_ms" integer,
+      "total_tokens" integer,
+      "input_tokens" integer,
+      "output_tokens" integer,
+      "cache_read_input_tokens" integer,
+      "cache_creation_input_tokens" integer,
+      "num_turns" integer,
+      "total_cost_usd" text,
+      "dependency_install_total_ms" integer,
+      "dependency_install_calls" integer,
+      "modified_file_count" integer,
+      "completed_todo_count" integer,
+      "error" text,
+      "metrics" jsonb NOT NULL,
+      "created_at" timestamp DEFAULT now() NOT NULL
+    )
+  `);
+
+  await db.execute(sql`
+    DO $$ BEGIN
+      ALTER TABLE "build_metrics"
+        ADD CONSTRAINT "build_metrics_project_id_projects_id_fk"
+        FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id")
+        ON DELETE cascade ON UPDATE no action;
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+      WHEN undefined_table THEN null;
+    END $$
+  `);
+
+  await db.execute(sql`
+    DO $$ BEGIN
+      ALTER TABLE "build_metrics"
+        ADD CONSTRAINT "build_metrics_session_id_generation_sessions_id_fk"
+        FOREIGN KEY ("session_id") REFERENCES "public"."generation_sessions"("id")
+        ON DELETE set null ON UPDATE no action;
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+      WHEN undefined_table THEN null;
+    END $$
+  `);
+
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS "build_metrics_project_id_idx" ON "build_metrics" ("project_id")`);
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS "build_metrics_session_id_idx" ON "build_metrics" ("session_id")`);
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS "build_metrics_build_id_idx" ON "build_metrics" ("build_id")`);
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS "build_metrics_created_at_idx" ON "build_metrics" ("created_at")`);
+  await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS "build_metrics_command_id_unique" ON "build_metrics" ("command_id")`);
+}
 
 const dev = process.env.NODE_ENV !== 'production';
 const hostname = process.env.HOSTNAME || 'localhost';
@@ -51,7 +120,18 @@ const WS_PATHS = ['/ws', '/ws/runner'];
 const app = next({ dev, hostname, port });
 const handle = app.getRequestHandler();
 
-app.prepare().then(() => {
+app.prepare().then(async () => {
+  if (process.env.DATABASE_URL) {
+    try {
+      await ensureBuildMetricsTable();
+      console.log('[server] build_metrics table ready');
+    } catch (error) {
+      console.error('[server] Failed to ensure build_metrics table (continuing startup):', error);
+    }
+  } else {
+    console.warn('[server] DATABASE_URL not set; skipping build_metrics ensure');
+  }
+
   // Create HTTP server
   const server = createServer(async (req, res) => {
     try {

--- a/apps/hatchway/src/app/api/build-events/route.ts
+++ b/apps/hatchway/src/app/api/build-events/route.ts
@@ -16,6 +16,7 @@ import { NextResponse } from 'next/server';
 import { randomUUID } from 'crypto';
 import { db } from '@hatchway/agent-core/lib/db/client';
 import {
+  buildMetrics,
   generationSessions,
   generationTodos,
   generationToolCalls,
@@ -24,6 +25,30 @@ import {
 import { eq, and, sql } from 'drizzle-orm';
 import { buildWebSocketServer } from '@hatchway/agent-core/lib/websocket/server';
 import { authenticateRunnerKey, extractRunnerKey, isLocalMode } from '@/lib/auth-helpers';
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asFiniteInt(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return Math.round(value);
+}
+
+function asOptionalText(value: unknown, maxLen = 500): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, maxLen);
+}
+
+function asCostText(value: unknown): string | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  if (typeof value === 'string' && value.trim()) return value.trim().slice(0, 64);
+  return null;
+}
 
 const SHARED_SECRET = process.env.RUNNER_SHARED_SECRET;
 
@@ -715,16 +740,115 @@ export async function POST(request: Request) {
       }
 
       case 'build-metrics': {
-        // Deliberately log a single structured record instead of adding a schema
-        // migration in the first observability slice. Railway/log collectors can
-        // query this stable prefix and parse the JSON payload.
-        console.log(`[build-metrics] ${JSON.stringify({
+        const metrics = asRecord(event.metrics);
+        const timings = asRecord(metrics.timings);
+        const tokens = asRecord(metrics.tokens);
+        const agentMetrics = asRecord(metrics.agentMetrics);
+        const dependencies = asRecord(metrics.dependencies);
+        const output = asRecord(metrics.output);
+
+        const resolvedCommandId =
+          asOptionalText(metrics.commandId ?? commandId, 200) ?? null;
+        const resolvedBuildId =
+          asOptionalText(metrics.buildId ?? buildId, 200) ?? null;
+        const resolvedStatus =
+          asOptionalText(metrics.status, 32) ?? 'unknown';
+
+        const row = {
           projectId,
           sessionId,
-          buildId,
-          commandId,
-          ...(event.metrics ?? {}),
-        })}`);
+          buildId: resolvedBuildId,
+          commandId: resolvedCommandId,
+          status: resolvedStatus,
+          agent: asOptionalText(metrics.agent, 100),
+          model: asOptionalText(metrics.model, 200),
+          totalMs: asFiniteInt(timings.totalMs),
+          orchestrationMs: asFiniteInt(timings.orchestrationMs),
+          agentMs: asFiniteInt(timings.agentMs),
+          timeToFirstChunkMs: asFiniteInt(timings.timeToFirstChunkMs),
+          runnerOverheadMs: asFiniteInt(timings.runnerOverheadMs),
+          totalTokens: asFiniteInt(tokens.total),
+          inputTokens: asFiniteInt(tokens.input),
+          outputTokens: asFiniteInt(tokens.output),
+          cacheReadInputTokens: asFiniteInt(tokens.cacheReadInput),
+          cacheCreationInputTokens: asFiniteInt(tokens.cacheCreationInput),
+          numTurns: asFiniteInt(agentMetrics.numTurns),
+          totalCostUsd: asCostText(agentMetrics.totalCostUsd),
+          dependencyInstallTotalMs: asFiniteInt(dependencies.installTotalMs),
+          dependencyInstallCalls: asFiniteInt(dependencies.installCalls),
+          modifiedFileCount: asFiniteInt(output.modifiedFileCount),
+          completedTodoCount: asFiniteInt(output.completedTodoCount),
+          error: asOptionalText(metrics.error, 500),
+          metrics: {
+            projectId,
+            sessionId,
+            buildId: resolvedBuildId,
+            commandId: resolvedCommandId,
+            ...metrics,
+          },
+        };
+
+        try {
+          if (resolvedCommandId) {
+            await db.insert(buildMetrics).values(row).onConflictDoUpdate({
+              target: buildMetrics.commandId,
+              set: {
+                projectId: row.projectId,
+                sessionId: row.sessionId,
+                buildId: row.buildId,
+                status: row.status,
+                agent: row.agent,
+                model: row.model,
+                totalMs: row.totalMs,
+                orchestrationMs: row.orchestrationMs,
+                agentMs: row.agentMs,
+                timeToFirstChunkMs: row.timeToFirstChunkMs,
+                runnerOverheadMs: row.runnerOverheadMs,
+                totalTokens: row.totalTokens,
+                inputTokens: row.inputTokens,
+                outputTokens: row.outputTokens,
+                cacheReadInputTokens: row.cacheReadInputTokens,
+                cacheCreationInputTokens: row.cacheCreationInputTokens,
+                numTurns: row.numTurns,
+                totalCostUsd: row.totalCostUsd,
+                dependencyInstallTotalMs: row.dependencyInstallTotalMs,
+                dependencyInstallCalls: row.dependencyInstallCalls,
+                modifiedFileCount: row.modifiedFileCount,
+                completedTodoCount: row.completedTodoCount,
+                error: row.error,
+                metrics: row.metrics,
+              },
+            });
+          } else {
+            await db.insert(buildMetrics).values(row);
+          }
+
+          console.log(`[build-metrics] persisted ${JSON.stringify({
+            projectId,
+            sessionId,
+            buildId: resolvedBuildId,
+            commandId: resolvedCommandId,
+            status: resolvedStatus,
+            totalMs: row.totalMs,
+            agentMs: row.agentMs,
+            orchestrationMs: row.orchestrationMs,
+            dependencyInstallTotalMs: row.dependencyInstallTotalMs,
+            totalTokens: row.totalTokens,
+            agent: row.agent,
+            model: row.model,
+          })}`);
+        } catch (metricsError) {
+          // Keep the log fallback so we never lose the payload if the table
+          // is missing or a write fails before migrations land.
+          console.error('[build-metrics] failed to persist metrics', metricsError);
+          console.log(`[build-metrics] ${JSON.stringify({
+            projectId,
+            sessionId,
+            buildId,
+            commandId,
+            ...metrics,
+          })}`);
+        }
         break;
       }
 

--- a/apps/hatchway/src/app/api/build-metrics/route.ts
+++ b/apps/hatchway/src/app/api/build-metrics/route.ts
@@ -1,0 +1,158 @@
+import { NextResponse } from 'next/server';
+import { db } from '@hatchway/agent-core/lib/db/client';
+import { buildMetrics, projects } from '@hatchway/agent-core/lib/db/schema';
+import { and, desc, eq, sql, type SQL } from 'drizzle-orm';
+import {
+  handleAuthError,
+  isLocalMode,
+  isProjectAccessibleBy,
+  requireAuth,
+  requireOperationalAccess,
+} from '@/lib/auth-helpers';
+
+function parseLimit(value: string | null, fallback = 25, max = 100): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(parsed, max);
+}
+
+/**
+ * GET /api/build-metrics
+ *
+ * Inspect recent build timing/cost metrics.
+ * Auth:
+ * - local mode: open
+ * - signed-in users: own projects (or legacy null-owner)
+ * - OPS_SECRET bearer: all projects
+ *
+ * Query params:
+ * - projectId?: uuid
+ * - buildId?: string
+ * - commandId?: string
+ * - limit?: number (default 25, max 100)
+ * - includeRaw?: "1" to include full metrics JSON
+ */
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const projectId = url.searchParams.get('projectId');
+    const buildId = url.searchParams.get('buildId');
+    const commandId = url.searchParams.get('commandId');
+    const includeRaw = url.searchParams.get('includeRaw') === '1';
+    const limit = parseLimit(url.searchParams.get('limit'));
+
+    let allowAllProjects = isLocalMode();
+    let userId: string | null = null;
+
+    if (!allowAllProjects) {
+      const opsSecret = process.env.OPS_SECRET;
+      const authHeader = request.headers.get('Authorization');
+      if (opsSecret && authHeader) {
+        try {
+          await requireOperationalAccess(request);
+          allowAllProjects = true;
+        } catch {
+          // Fall through to session auth
+        }
+      }
+
+      if (!allowAllProjects) {
+        const session = await requireAuth();
+        userId = session.user.id;
+      }
+    }
+
+    if (!allowAllProjects && projectId) {
+      const project = await db.query.projects.findFirst({
+        where: eq(projects.id, projectId),
+        columns: { id: true, userId: true },
+      });
+      if (!project) {
+        return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+      }
+      if (!userId || !isProjectAccessibleBy(project, userId)) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+    }
+
+    const conditions: SQL[] = [];
+    if (projectId) conditions.push(eq(buildMetrics.projectId, projectId));
+    if (buildId) conditions.push(eq(buildMetrics.buildId, buildId));
+    if (commandId) conditions.push(eq(buildMetrics.commandId, commandId));
+
+    // When scoped to a user without a project filter, over-fetch then filter.
+    const fetchLimit = allowAllProjects || projectId ? limit : Math.min(limit * 5, 200);
+
+    const rows = await db
+      .select({
+        id: buildMetrics.id,
+        projectId: buildMetrics.projectId,
+        sessionId: buildMetrics.sessionId,
+        buildId: buildMetrics.buildId,
+        commandId: buildMetrics.commandId,
+        status: buildMetrics.status,
+        agent: buildMetrics.agent,
+        model: buildMetrics.model,
+        totalMs: buildMetrics.totalMs,
+        orchestrationMs: buildMetrics.orchestrationMs,
+        agentMs: buildMetrics.agentMs,
+        timeToFirstChunkMs: buildMetrics.timeToFirstChunkMs,
+        runnerOverheadMs: buildMetrics.runnerOverheadMs,
+        totalTokens: buildMetrics.totalTokens,
+        inputTokens: buildMetrics.inputTokens,
+        outputTokens: buildMetrics.outputTokens,
+        cacheReadInputTokens: buildMetrics.cacheReadInputTokens,
+        cacheCreationInputTokens: buildMetrics.cacheCreationInputTokens,
+        numTurns: buildMetrics.numTurns,
+        totalCostUsd: buildMetrics.totalCostUsd,
+        dependencyInstallTotalMs: buildMetrics.dependencyInstallTotalMs,
+        dependencyInstallCalls: buildMetrics.dependencyInstallCalls,
+        modifiedFileCount: buildMetrics.modifiedFileCount,
+        completedTodoCount: buildMetrics.completedTodoCount,
+        error: buildMetrics.error,
+        createdAt: buildMetrics.createdAt,
+        ...(includeRaw ? { metrics: buildMetrics.metrics } : {}),
+        projectName: projects.name,
+        projectSlug: projects.slug,
+        projectUserId: projects.userId,
+        isAutoFix: sql<boolean | null>`(
+          select gs.is_auto_fix
+          from generation_sessions gs
+          where gs.id = ${buildMetrics.sessionId}
+          limit 1
+        )`,
+      })
+      .from(buildMetrics)
+      .leftJoin(projects, eq(buildMetrics.projectId, projects.id))
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(desc(buildMetrics.createdAt))
+      .limit(fetchLimit);
+
+    const filtered = (allowAllProjects || projectId
+      ? rows
+      : rows.filter((row) =>
+          isProjectAccessibleBy({ userId: row.projectUserId }, userId!)
+        )
+    ).slice(0, limit);
+
+    const metrics = filtered.map(({ projectUserId: _projectUserId, ...rest }) => rest);
+
+    return NextResponse.json({
+      count: metrics.length,
+      metrics,
+    });
+  } catch (error) {
+    const authResponse = handleAuthError(error);
+    if (authResponse) return authResponse;
+
+    console.error('[build-metrics] Failed to list metrics:', error);
+    return NextResponse.json(
+      {
+        error: 'Failed to list build metrics',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/agent-core/src/lib/db/schema.ts
+++ b/packages/agent-core/src/lib/db/schema.ts
@@ -267,6 +267,45 @@ export const generationNotes = pgTable('generation_notes', {
     .where(sql`${table.textId} is not null`),
 }));
 
+// Durable build timing/cost metrics emitted by the runner at build end.
+// Full payload is kept in `metrics` JSONB; key fields are denormalized for SQL.
+export const buildMetrics = pgTable('build_metrics', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  projectId: uuid('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
+  sessionId: uuid('session_id').references(() => generationSessions.id, { onDelete: 'set null' }),
+  buildId: text('build_id'),
+  commandId: text('command_id'),
+  status: text('status').notNull(), // 'completed' | 'failed'
+  agent: text('agent'),
+  model: text('model'),
+  totalMs: integer('total_ms'),
+  orchestrationMs: integer('orchestration_ms'),
+  agentMs: integer('agent_ms'),
+  timeToFirstChunkMs: integer('time_to_first_chunk_ms'),
+  runnerOverheadMs: integer('runner_overhead_ms'),
+  totalTokens: integer('total_tokens'),
+  inputTokens: integer('input_tokens'),
+  outputTokens: integer('output_tokens'),
+  cacheReadInputTokens: integer('cache_read_input_tokens'),
+  cacheCreationInputTokens: integer('cache_creation_input_tokens'),
+  numTurns: integer('num_turns'),
+  totalCostUsd: text('total_cost_usd'),
+  dependencyInstallTotalMs: integer('dependency_install_total_ms'),
+  dependencyInstallCalls: integer('dependency_install_calls'),
+  modifiedFileCount: integer('modified_file_count'),
+  completedTodoCount: integer('completed_todo_count'),
+  error: text('error'),
+  metrics: jsonb('metrics').notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+}, (table) => ({
+  projectIdIdx: index('build_metrics_project_id_idx').on(table.projectId),
+  sessionIdIdx: index('build_metrics_session_id_idx').on(table.sessionId),
+  buildIdIdx: index('build_metrics_build_id_idx').on(table.buildId),
+  createdAtIdx: index('build_metrics_created_at_idx').on(table.createdAt),
+  // Postgres UNIQUE allows multiple NULLs, so missing commandIds still insert.
+  commandIdUnique: uniqueIndex('build_metrics_command_id_unique').on(table.commandId),
+}));
+
 // ============================================================================
 // Railway Integration Tables
 // ============================================================================
@@ -408,6 +447,8 @@ export type GenerationSession = typeof generationSessions.$inferSelect;
 export type GenerationTodo = typeof generationTodos.$inferSelect;
 export type GenerationToolCall = typeof generationToolCalls.$inferSelect;
 export type GenerationNote = typeof generationNotes.$inferSelect;
+export type BuildMetric = typeof buildMetrics.$inferSelect;
+export type NewBuildMetric = typeof buildMetrics.$inferInsert;
 
 // Railway integration types
 export type RailwayConnection = typeof railwayConnections.$inferSelect;


### PR DESCRIPTION
## Summary
- Add `build_metrics` table (schema + SQL migration + idempotent startup ensure)
- Persist runner `build-metrics` events in `/api/build-events` with upsert by `commandId`
- Add authenticated `GET /api/build-metrics` for post-build inspection

## Test plan
- [ ] Deploy/merge and confirm hatchway logs `build_metrics table ready`
- [ ] Run 1-2 builds
- [ ] `GET /api/build-metrics?limit=10` (signed in) returns rows with total/orchestration/agent/install timings
- [ ] `GET /api/build-metrics?includeRaw=1&limit=1` returns full metrics JSON