### PR TITLE
perf: cut Claude build turns and tool surface

### DIFF
--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -888,7 +888,8 @@ const ENABLE_FACTORY_SDK = process.env.ENABLE_FACTORY_SDK === 'true';
 function createBuildQuery(
   agent: AgentId,
   modelId?: ClaudeModelId | OpenCodeModelId,
-  abortController?: AbortController
+  abortController?: AbortController,
+  operationType?: string,
 ): BuildQueryFn {
   // When OpenCode SDK is enabled, route ALL requests through it (including Codex)
   if (ENABLE_OPENCODE_SDK) {
@@ -912,15 +913,19 @@ function createBuildQuery(
     if (!ENABLE_FACTORY_SDK) {
       console.warn('[runner] ⚠️ Factory Droid requested but ENABLE_FACTORY_SDK is not set');
       console.warn('[runner] ⚠️ Falling back to native Claude Agent SDK');
-      return createNativeClaudeQuery(DEFAULT_CLAUDE_MODEL_ID, abortController);
+      return createNativeClaudeQuery(DEFAULT_CLAUDE_MODEL_ID, abortController, { operationType });
     }
     console.log('[runner] 🔄 Using Factory Droid SDK');
     return createDroidQuery(modelId as string);
   }
 
   // Default: Use native Claude Agent SDK (direct integration)
-  console.log('[runner] 🔄 Using NATIVE Claude Agent SDK');
-  return createNativeClaudeQuery((modelId as ClaudeModelId) ?? DEFAULT_CLAUDE_MODEL_ID, abortController);
+  console.log(`[runner] 🔄 Using NATIVE Claude Agent SDK (op=${operationType ?? 'default'})`);
+  return createNativeClaudeQuery(
+    (modelId as ClaudeModelId) ?? DEFAULT_CLAUDE_MODEL_ID,
+    abortController,
+    { operationType },
+  );
 }
 
 /**
@@ -2417,7 +2422,12 @@ export async function startRunner(options: RunnerOptions = {}) {
 
           // Select the appropriate model for the agent
           const modelId = agent === "factory-droid" ? droidModel : claudeModel;
-          const agentQuery = createBuildQuery(agent, modelId as ClaudeModelId, buildAbortController);
+          const agentQuery = createBuildQuery(
+            agent,
+            modelId as ClaudeModelId,
+            buildAbortController,
+            command.payload.operationType,
+          );
 
           // Reset transformer state for new build
           resetTransformerState();

--- a/apps/runner/src/lib/native-claude-sdk.ts
+++ b/apps/runner/src/lib/native-claude-sdk.ts
@@ -201,6 +201,46 @@ function buildPromptWithImages(prompt: string, messageParts?: MessagePart[]): st
 }
 
 /**
+ * Operation-aware turn budgets. Production builds were spending most wall time
+ * in model turns (not tools); caps prevent long exploratory loops while still
+ * leaving headroom for real multi-file work.
+ */
+export function resolveClaudeMaxTurns(operationType?: string): number {
+  switch (operationType) {
+    case 'autofix':
+      return 20;
+    case 'focused-edit':
+      return 15;
+    case 'enhancement':
+      return 35;
+    case 'continuation':
+      return 30;
+    case 'initial-build':
+    default:
+      return 40;
+  }
+}
+
+/** Core coding tools only — blocks TodoWrite/Task/MCP/web that burn turns. */
+const CLAUDE_BUILD_TOOLS = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'] as const;
+
+const CLAUDE_DISALLOWED_TOOLS = [
+  'TodoWrite',
+  'Task',
+  'ExitPlanMode',
+  'AskUserQuestion',
+  'Skill',
+  'WebSearch',
+  'WebFetch',
+  'NotebookEdit',
+] as const;
+
+export interface NativeClaudeQueryOptions {
+  maxTurns?: number;
+  operationType?: string;
+}
+
+/**
  * Create a native Claude query function using the official SDK directly
  *
  * This replaces the previous approach of:
@@ -211,8 +251,12 @@ function buildPromptWithImages(prompt: string, messageParts?: MessagePart[]): st
  */
 export function createNativeClaudeQuery(
   modelId: ClaudeModelId = DEFAULT_CLAUDE_MODEL_ID,
-  abortController?: AbortController
+  abortController?: AbortController,
+  queryOptions: NativeClaudeQueryOptions = {},
 ) {
+  const resolvedMaxTurns =
+    queryOptions.maxTurns ?? resolveClaudeMaxTurns(queryOptions.operationType);
+
   return async function* nativeClaudeQuery(
     prompt: string,
     workingDirectory: string,
@@ -225,6 +269,7 @@ export function createNativeClaudeQuery(
     debugLog(`[runner] [native-sdk] Model: ${modelId}\n`);
     debugLog(`[runner] [native-sdk] Working dir: ${workingDirectory}\n`);
     debugLog(`[runner] [native-sdk] Prompt length: ${prompt.length}\n`);
+    debugLog(`[runner] [native-sdk] maxTurns: ${resolvedMaxTurns} (op=${queryOptions.operationType ?? 'default'})\n`);
 
     // Build combined system prompt
     const systemPromptSegments: string[] = [CLAUDE_SYSTEM_PROMPT.trim()];
@@ -259,7 +304,7 @@ export function createNativeClaudeQuery(
       cwd: workingDirectory,
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true, // Required for bypassPermissions
-      maxTurns: 100,
+      maxTurns: resolvedMaxTurns,
       additionalDirectories: [workingDirectory],
       canUseTool: createProjectScopedPermissionHandler(workingDirectory),
       includePartialMessages: false, // We don't need streaming deltas
@@ -279,9 +324,10 @@ export function createNativeClaudeQuery(
         // Enable SDK debug logging only when explicitly diagnosing the SDK.
         ...(process.env.DEBUG_SKILLS === '1' ? { DEBUG_CLAUDE_AGENT_SDK: '1' } : {}),
       },
-      // Use Claude Code's file, search, shell, and web tools. Progress is sent
-      // through the inline TODO_WRITE protocol rather than extra task-tool turns.
-      tools: { type: 'preset', preset: 'claude_code' },
+      // Restrict to coding tools only. Progress uses inline TODO_WRITE text;
+      // TodoWrite/Task/MCP/web tools only add expensive turns.
+      tools: [...CLAUDE_BUILD_TOOLS],
+      disallowedTools: [...CLAUDE_DISALLOWED_TOOLS],
       // Pass abort controller for cancellation support
       // NOTE: There is a known bug in the Claude Agent SDK where AbortController
       // signals are not fully respected. When abort() is called, the SDK may

--- a/apps/runner/src/lib/permissions/project-scoped-handler.ts
+++ b/apps/runner/src/lib/permissions/project-scoped-handler.ts
@@ -29,10 +29,33 @@ type CanUseToolFn = (
  * @param projectDirectory Absolute path to the project directory (e.g., /Users/codydearkland/hatchway-workspace/codyscoolnewapp)
  * @returns Permission handler function for use with Claude Agent SDK
  */
+const LATENCY_BLOCKED_TOOLS = new Set([
+  'TodoWrite',
+  'Task',
+  'ExitPlanMode',
+  'AskUserQuestion',
+  'Skill',
+  'WebSearch',
+  'WebFetch',
+  'NotebookEdit',
+]);
+
 export function createProjectScopedPermissionHandler(projectDirectory: string): CanUseToolFn {
   const normalizedProjectDir = resolve(projectDirectory);
 
   return async (toolName, input, { signal, suggestions }) => {
+    // Block high-latency / non-coding tools even if the SDK exposes them.
+    if (LATENCY_BLOCKED_TOOLS.has(toolName) || toolName.startsWith('mcp__')) {
+      console.warn(`[permissions] DENIED ${toolName} - not allowed during Hatchway builds`);
+      return {
+        behavior: 'deny',
+        message:
+          `Tool "${toolName}" is disabled for Hatchway builds. ` +
+          'Use Bash/Read/Write/Edit/Glob/Grep only, and emit TODO_WRITE text markers for progress.',
+        interrupt: false,
+      };
+    }
+
     // Helper: Check if a path is within the project directory
     const isWithinProject = (filePath: string): boolean => {
       const absPath = resolve(normalizedProjectDir, filePath);

--- a/apps/runner/src/lib/templates/manifest.ts
+++ b/apps/runner/src/lib/templates/manifest.ts
@@ -9,10 +9,11 @@ export interface ProjectManifestOptions {
   maxContentChars?: number;
 }
 
-const DEFAULT_MAX_DEPTH = 5;
-const DEFAULT_MAX_ENTRIES = 220;
-const DEFAULT_MAX_CONTENT_CHARS = 24_000;
-const MAX_FILE_CHARS = 6_000;
+// Keep the injected project tree lean so first-turn prefill stays small.
+const DEFAULT_MAX_DEPTH = 4;
+const DEFAULT_MAX_ENTRIES = 120;
+const DEFAULT_MAX_CONTENT_CHARS = 16_000;
+const MAX_FILE_CHARS = 4_000;
 
 const EXCLUDED_DIRECTORIES = new Set([
   '.git',

--- a/packages/agent-core/src/lib/agents/claude-strategy.ts
+++ b/packages/agent-core/src/lib/agents/claude-strategy.ts
@@ -127,11 +127,25 @@ ${context.fileTree}`);
 
 function buildFullPrompt(context: AgentStrategyContext, basePrompt: string): string {
   if (!context.isNewProject) {
+    if (context.operationType === 'autofix') {
+      return `${basePrompt}
+
+## Autofix Speed Rules
+1. Diagnose from the error first; only open files implicated by the stack/log.
+2. Make the smallest fix that restores startup; avoid refactors and design changes.
+3. Re-run the failing command once, fix remaining errors, then stop.`;
+    }
     return basePrompt;
   }
   return `${basePrompt}
 
-CRITICAL: The template has already been prepared in ${context.workingDirectory}. Do not scaffold a new project.`;
+CRITICAL: The template has already been prepared in ${context.workingDirectory}. Do not scaffold a new project.
+
+## Speed Rules
+1. Emit one short TODO_WRITE plan (≤8 items), then implement immediately.
+2. Do not fetch external docs, browse the web, or explore alternative architectures.
+3. One dependency install after package.json changes; one build/typecheck; fix only real failures.
+4. Finish when the request is met and validation is clean — no extra polish turns.`;
 }
 
 const claudeStrategy: AgentStrategy = {

--- a/packages/agent-core/src/lib/prompts.ts
+++ b/packages/agent-core/src/lib/prompts.ts
@@ -12,10 +12,12 @@ export const CLAUDE_SYSTEM_PROMPT = `You are an elite coding assistant specializ
 
 - Begin project work immediately. Do not load skills or plugins, and do not enter plan mode unless the user explicitly asks for a plan.
 - Read the relevant existing files before editing. Preserve working scaffold behavior and customize it instead of generating a replacement app.
-- For multi-step work, show progress by emitting a single-line marker in normal assistant text: \`TODO_WRITE: {"todos":[...]}\`. Each todo needs \`content\`, \`activeForm\`, and a \`status\` of \`pending\`, \`in_progress\`, or \`completed\`. Emit the complete list on every update; keep exactly one item in progress until all work is complete. Do not call TodoWrite or Task tools.
+- For multi-step work, show progress by emitting a single-line marker in normal assistant text: \`TODO_WRITE: {"todos":[...]}\`. Each todo needs \`content\`, \`activeForm\`, and a \`status\` of \`pending\`, \`in_progress\`, or \`completed\`. Emit the complete list on every update; keep exactly one item in progress until all work is complete. Do not call TodoWrite, Task, Skill, WebSearch, WebFetch, or any MCP tools.
+- Keep plans short (ideally 4-8 todos). Prefer Write/Edit over long exploratory Bash sessions.
 - Inspect package files first, make all code and dependency-manifest changes, then install dependencies together once. For npm, prefer \`npm install --prefer-offline --no-audit --no-fund\`. Do not repeatedly install packages one at a time.
 - For UI work, produce a coherent, responsive, accessible design with intentional typography, spacing, hierarchy, and interaction states. Avoid generic placeholder styling and unnecessary rewrites.
 - Run the project's build or typecheck after implementation. Fix errors and rerun until clean. Only start a dev server once, at the end when runtime verification is useful, and stop it afterward.
+- Stop as soon as the request is met and validation is clean. Do not keep polishing, researching alternatives, or adding unrequested scope.
 - Work quietly between progress updates. Finish with a concise summary of what changed and what validation passed.
 
 ## Plan Mode


### PR DESCRIPTION
## Summary
- Cap Claude `maxTurns` by operation (`initial-build` 40, `enhancement` 35, `autofix` 20, `focused-edit` 15)
- Restrict Claude tools to Bash/Read/Write/Edit/Glob/Grep and deny TodoWrite/Task/MCP/web
- Tighten build/autofix prompts for short plans and early stop
- Shrink injected project manifest defaults for faster first-turn prefill

## Why
First production metrics row was ~7.3 min with 99.8% in the agent loop (53 turns, ~20s tool wall). Biggest lever is fewer model turns and no junk tools.

## Test plan
- [ ] Run an initial Claude build and confirm logs show `maxTurns: 40`
- [ ] Confirm build metrics `numTurns` is materially lower than 53 on a similar prompt
- [ ] Confirm TodoWrite/MCP tools are not used (or denied)
- [ ] Spot-check autofix still recovers startup errors within 20 turns