### PR TITLE
fix: restore TodoWrite and web tools for Claude builds

### DIFF
--- a/apps/runner/src/lib/native-claude-sdk.ts
+++ b/apps/runner/src/lib/native-claude-sdk.ts
@@ -221,17 +221,32 @@ export function resolveClaudeMaxTurns(operationType?: string): number {
   }
 }
 
-/** Core coding tools only — blocks TodoWrite/Task/MCP/web that burn turns. */
-const CLAUDE_BUILD_TOOLS = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'] as const;
+/**
+ * Build tool surface:
+ * - coding tools for implementation
+ * - TodoWrite for native build progress tracking
+ * - WebSearch/WebFetch for docs/context lookup
+ *
+ * Task stays disallowed: it spawns nested agent loops and is not used for
+ * Hatchway progress tracking (TodoWrite is).
+ */
+const CLAUDE_BUILD_TOOLS = [
+  'Bash',
+  'Read',
+  'Write',
+  'Edit',
+  'Glob',
+  'Grep',
+  'TodoWrite',
+  'WebSearch',
+  'WebFetch',
+] as const;
 
 const CLAUDE_DISALLOWED_TOOLS = [
-  'TodoWrite',
   'Task',
   'ExitPlanMode',
   'AskUserQuestion',
   'Skill',
-  'WebSearch',
-  'WebFetch',
   'NotebookEdit',
 ] as const;
 
@@ -324,8 +339,7 @@ export function createNativeClaudeQuery(
         // Enable SDK debug logging only when explicitly diagnosing the SDK.
         ...(process.env.DEBUG_SKILLS === '1' ? { DEBUG_CLAUDE_AGENT_SDK: '1' } : {}),
       },
-      // Restrict to coding tools only. Progress uses inline TODO_WRITE text;
-      // TodoWrite/Task/MCP/web tools only add expensive turns.
+      // Coding + TodoWrite progress + web research. Task/MCP/plan tools stay off.
       tools: [...CLAUDE_BUILD_TOOLS],
       disallowedTools: [...CLAUDE_DISALLOWED_TOOLS],
       // Pass abort controller for cancellation support

--- a/apps/runner/src/lib/permissions/project-scoped-handler.ts
+++ b/apps/runner/src/lib/permissions/project-scoped-handler.ts
@@ -29,14 +29,12 @@ type CanUseToolFn = (
  * @param projectDirectory Absolute path to the project directory (e.g., /Users/codydearkland/hatchway-workspace/codyscoolnewapp)
  * @returns Permission handler function for use with Claude Agent SDK
  */
+// Nested agents / plan-mode / skills burn turns. TodoWrite + web stay allowed.
 const LATENCY_BLOCKED_TOOLS = new Set([
-  'TodoWrite',
   'Task',
   'ExitPlanMode',
   'AskUserQuestion',
   'Skill',
-  'WebSearch',
-  'WebFetch',
   'NotebookEdit',
 ]);
 
@@ -44,14 +42,14 @@ export function createProjectScopedPermissionHandler(projectDirectory: string): 
   const normalizedProjectDir = resolve(projectDirectory);
 
   return async (toolName, input, { signal, suggestions }) => {
-    // Block high-latency / non-coding tools even if the SDK exposes them.
+    // Block nested-agent / plan tools and personal MCP even if the SDK exposes them.
     if (LATENCY_BLOCKED_TOOLS.has(toolName) || toolName.startsWith('mcp__')) {
       console.warn(`[permissions] DENIED ${toolName} - not allowed during Hatchway builds`);
       return {
         behavior: 'deny',
         message:
           `Tool "${toolName}" is disabled for Hatchway builds. ` +
-          'Use Bash/Read/Write/Edit/Glob/Grep only, and emit TODO_WRITE text markers for progress.',
+          'Use Bash/Read/Write/Edit/Glob/Grep, TodoWrite for progress, and WebSearch/WebFetch for docs.',
         interrupt: false,
       };
     }

--- a/packages/agent-core/src/lib/agents/claude-strategy.ts
+++ b/packages/agent-core/src/lib/agents/claude-strategy.ts
@@ -142,8 +142,8 @@ function buildFullPrompt(context: AgentStrategyContext, basePrompt: string): str
 CRITICAL: The template has already been prepared in ${context.workingDirectory}. Do not scaffold a new project.
 
 ## Speed Rules
-1. Emit one short TODO_WRITE plan (≤8 items), then implement immediately.
-2. Do not fetch external docs, browse the web, or explore alternative architectures.
+1. Emit one short TodoWrite plan (≤8 items), then implement immediately.
+2. Use WebSearch/WebFetch only for missing external docs/API details; do not explore alternative architectures.
 3. One dependency install after package.json changes; one build/typecheck; fix only real failures.
 4. Finish when the request is met and validation is clean — no extra polish turns.`;
 }

--- a/packages/agent-core/src/lib/prompts.ts
+++ b/packages/agent-core/src/lib/prompts.ts
@@ -12,8 +12,9 @@ export const CLAUDE_SYSTEM_PROMPT = `You are an elite coding assistant specializ
 
 - Begin project work immediately. Do not load skills or plugins, and do not enter plan mode unless the user explicitly asks for a plan.
 - Read the relevant existing files before editing. Preserve working scaffold behavior and customize it instead of generating a replacement app.
-- For multi-step work, show progress by emitting a single-line marker in normal assistant text: \`TODO_WRITE: {"todos":[...]}\`. Each todo needs \`content\`, \`activeForm\`, and a \`status\` of \`pending\`, \`in_progress\`, or \`completed\`. Emit the complete list on every update; keep exactly one item in progress until all work is complete. Do not call TodoWrite, Task, Skill, WebSearch, WebFetch, or any MCP tools.
-- Keep plans short (ideally 4-8 todos). Prefer Write/Edit over long exploratory Bash sessions.
+- For multi-step work, track progress with the TodoWrite tool (\`content\`, \`activeForm\`, \`status\` of \`pending\`/\`in_progress\`/\`completed\`). Keep the list short (4-8 items), emit the complete list on every update, and keep exactly one item in progress until done. Do not call Task, Skill, or MCP tools.
+- Use WebSearch/WebFetch only when you need external docs or API context you do not already have. Prefer local files and the project manifest first.
+- Prefer Write/Edit over long exploratory Bash sessions.
 - Inspect package files first, make all code and dependency-manifest changes, then install dependencies together once. For npm, prefer \`npm install --prefer-offline --no-audit --no-fund\`. Do not repeatedly install packages one at a time.
 - For UI work, produce a coherent, responsive, accessible design with intentional typography, spacing, hierarchy, and interaction states. Avoid generic placeholder styling and unnecessary rewrites.
 - Run the project's build or typecheck after implementation. Fix errors and rerun until clean. Only start a dev server once, at the end when runtime verification is useful, and stop it afterward.


### PR DESCRIPTION
## Summary
- Allow `TodoWrite`, `WebSearch`, and `WebFetch` again on Claude builds
- Keep `Task`/MCP/plan tools blocked (Task is nested agents, not build progress tracking)
- Update prompts to prefer TodoWrite tool + restrained web lookup

## Why
Web tools are needed for docs/context. TodoWrite is the native progress path used by the build UI. Task is not required for tracking and multiplies latency.

## Test plan
- [ ] Claude build can call TodoWrite and update UI todos
- [ ] Claude build can call WebSearch/WebFetch
- [ ] Task/MCP still denied