### PR TITLE
fix: treat early-stop aborts as successful builds

### DIFF
--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -423,6 +423,26 @@ function shouldEarlyStopOnTodos(
   return actionable.every((todo) => todo.status === 'completed');
 }
 
+function isAbortLikeError(error: unknown): boolean {
+  if (!error) return false;
+  if (typeof error === 'object') {
+    const err = error as { name?: string; message?: string; code?: string };
+    if (err.name === 'AbortError' || err.name === 'AbortSignal' || err.code === 'ABORT_ERR') {
+      return true;
+    }
+    const message = String(err.message ?? '').toLowerCase();
+    if (
+      message.includes('aborted') ||
+      message.includes('abort') ||
+      message.includes('this operation was aborted') ||
+      message.includes('controllermessagequeue')
+    ) {
+      return true;
+    }
+  }
+  return String(error).toLowerCase().includes('abort');
+}
+
 function createBuildMetrics(
   context: BuildContext,
   status: 'completed' | 'failed',
@@ -2465,6 +2485,15 @@ export async function startRunner(options: RunnerOptions = {}) {
         fileLog.info("Agent:", command.payload?.agent);
         fileLog.info("Template:", command.payload?.template);
 
+        // Early-stop is intentional success (todos done after implementation).
+        // Hoisted so abort/cancel errors can still complete the build cleanly.
+        let earlyStopTriggered = false;
+        let earlyStopReason: string | undefined;
+        const filesModified = new Set<string>();
+        const completedTodos: string[] = [];
+        let latestTodos: TrackedTodo[] = [];
+        let implementedViaTools = false;
+
         try {
           loggedFirstChunk = false;
           if (!command.payload?.prompt || !command.payload?.operationType) {
@@ -2672,24 +2701,23 @@ export async function startRunner(options: RunnerOptions = {}) {
           const decoder = new TextDecoder();
 
           let chunkCount = 0;
-          
-          // Track files modified and todos for build summary / early-stop.
-          const filesModified = new Set<string>();
-          const completedTodos: string[] = [];
-          let latestTodos: TrackedTodo[] = [];
-          let implementedViaTools = false;
-          let earlyStopTriggered = false;
+
           const requestEarlyStop = async (reason: string) => {
             if (earlyStopTriggered) return;
             earlyStopTriggered = true;
+            earlyStopReason = reason;
             buildLog(` ⏹️  Early stop: ${reason}`);
+            // Prefer cancelling the stream consumer first. Aborting the SDK is a
+            // best-effort follow-up; abort errors must not flip the build to failed.
             try {
               await reader.cancel(reason);
             } catch {
               // reader may already be closed
             }
             try {
-              buildAbortController.abort();
+              if (!buildAbortController.signal.aborted) {
+                buildAbortController.abort();
+              }
             } catch {
               // ignore repeated abort
             }
@@ -3112,7 +3140,7 @@ export async function startRunner(options: RunnerOptions = {}) {
                 completedTodoCount: completedTodos.length,
                 earlyStop: earlyStopTriggered,
                 earlyStopReason: earlyStopTriggered
-                  ? 'todos_completed_after_implementation'
+                  ? (earlyStopReason ?? 'todos_completed_after_implementation')
                   : undefined,
               },
             );
@@ -3240,6 +3268,89 @@ Write a brief, professional summary (1-3 sentences) describing what was accompli
           }
           activeBuildContexts.delete(command.id);
         } catch (error) {
+          // Intentional early-stop aborts the SDK/stream. Treat that as success
+          // if we already implemented work; otherwise keep the real failure path.
+          const abortLooksIntentional =
+            earlyStopTriggered ||
+            (isAbortLikeError(error) && (implementedViaTools || completedTodos.length > 0 || filesModified.size > 0));
+
+          if (abortLooksIntentional) {
+            earlyStopTriggered = true;
+            earlyStopReason ??= 'todos_completed_after_implementation';
+            buildLog(` ⏹️  Treating abort as successful early stop (${earlyStopReason})`);
+
+            const completedBuildContext = activeBuildContexts.get(command.id);
+            const earlyStopDirectory = completedBuildContext?.projectDirectory;
+            if (completedBuildContext && earlyStopDirectory) {
+              completedBuildContext.agentCompletedAt ??= Date.now();
+              try {
+                completedBuildContext.dependencyStateAfter = hasSuccessfulDependencyInstall(completedBuildContext)
+                  ? await recordDependencyState(earlyStopDirectory)
+                  : await inspectDependencyState(earlyStopDirectory);
+              } catch (dependencyStateError) {
+                log('[build] Failed to record dependency state after early stop:', dependencyStateError);
+              }
+            }
+
+            let detectedFramework: string | null = null;
+            if (earlyStopDirectory) {
+              try {
+                const { detectFrameworkFromFilesystem } = await import('@hatchway/agent-core/lib/port-allocator');
+                detectedFramework = await detectFrameworkFromFilesystem(earlyStopDirectory);
+              } catch (frameworkError) {
+                log('[build] Failed to detect framework after early stop:', frameworkError);
+              }
+            }
+
+            const buildEndTime = Date.now();
+            if (completedBuildContext) {
+              const buildMetrics = createBuildMetrics(
+                completedBuildContext,
+                'completed',
+                buildEndTime,
+                {
+                  modifiedFileCount: filesModified.size,
+                  completedTodoCount: completedTodos.length,
+                  earlyStop: true,
+                  earlyStopReason,
+                },
+              );
+              buildLog(`[timing] ${JSON.stringify(buildMetrics)}`);
+              void persistBuildEventDirect(completedBuildContext, {
+                type: 'build-metrics',
+                metrics: buildMetrics,
+              }).catch((metricsError) => {
+                debugLog('Failed to persist early-stop build metrics:', metricsError);
+              });
+            }
+
+            sendEvent({
+              type: "build-stream",
+              ...buildEventBase(command.projectId, command.id),
+              data: "data: [DONE]\n\n",
+            });
+            sendEvent({
+              type: "build-completed",
+              ...buildEventBase(command.projectId, command.id),
+              payload: {
+                todos: [],
+                detectedFramework,
+              },
+            });
+            sendEvent({
+              type: "ack",
+              ...buildEventBase(command.projectId, command.id),
+              message: "build-complete-ready-for-dev-server",
+            });
+
+            printEventSummary();
+            if (completedBuildContext) {
+              startedSessions.delete(completedBuildContext.sessionId);
+            }
+            activeBuildContexts.delete(command.id);
+            break;
+          }
+
           const errorMessage = error instanceof Error ? error.message : "Failed to run build";
           logger.buildFailed(errorMessage);
 

--- a/apps/runner/src/lib/build/engine.ts
+++ b/apps/runner/src/lib/build/engine.ts
@@ -127,8 +127,25 @@ export async function createBuildStream(options: BuildStreamOptions): Promise<Re
           debugLog(`[runner] [build-engine] ✅ Generator exhausted after ${chunkCount} chunks, closing stream\n`);
           controller.close();
         } catch (error) {
-          debugLog(`[runner] [build-engine] ❌ Error consuming generator: ${error}\n`);
-          controller.error(error);
+          const err = error as { name?: string; message?: string; code?: string } | null;
+          const message = String(err?.message ?? error ?? '').toLowerCase();
+          const isAbort =
+            err?.name === 'AbortError' ||
+            err?.code === 'ABORT_ERR' ||
+            message.includes('abort');
+
+          if (isAbort) {
+            // Early-stop / cancel: close cleanly so the runner can complete success path.
+            debugLog(`[runner] [build-engine] ⏹️  Generator aborted after ${chunkCount} chunks, closing stream\n`);
+            try {
+              controller.close();
+            } catch {
+              // already closed
+            }
+          } else {
+            debugLog(`[runner] [build-engine] ❌ Error consuming generator: ${error}\n`);
+            controller.error(error);
+          }
         } finally {
           // Restore the original working directory
           process.chdir(originalCwd);

--- a/apps/runner/src/lib/native-claude-sdk.ts
+++ b/apps/runner/src/lib/native-claude-sdk.ts
@@ -486,6 +486,21 @@ export function createNativeClaudeQuery(
 
       debugLog(`[runner] [native-sdk] 📊 Stream complete - ${messageCount} messages, ${toolCallCount} tool calls, ${textBlockCount} text blocks\n`);
     } catch (error) {
+      // Early-stop and user cancel abort the query. End the generator cleanly so
+      // the runner can mark the build completed instead of failed.
+      const err = error as { name?: string; message?: string; code?: string } | null;
+      const message = String(err?.message ?? error ?? '').toLowerCase();
+      const isAbort =
+        err?.name === 'AbortError' ||
+        err?.code === 'ABORT_ERR' ||
+        message.includes('abort') ||
+        abortController?.signal.aborted;
+
+      if (isAbort) {
+        debugLog(`[runner] [native-sdk] ⏹️  Query aborted after ${messageCount} messages (treating as clean stop)\n`);
+        return;
+      }
+
       debugLog(`[runner] [native-sdk] ❌ Error: ${error instanceof Error ? error.message : String(error)}\n`);
       throw error;
     }


### PR DESCRIPTION
## Summary
- Intentional early-stop / abort no longer emits `build-failed`
- Native Claude SDK and build stream close cleanly on abort
- Catch path still completes metrics + `build-completed` when abort happens after real implementation work

## Why
Users saw "Build failed. Review the summary or retry the request." even when the app preview came up, because early-stop aborted the agent loop and that abort was treated as failure.

## Test plan
- [ ] Run a Claude build that completes todos
- [ ] Confirm UI shows completed (not failed/cancelled banner)
- [ ] Confirm `build-completed` lands and project status is completed
- [ ] Confirm real failures still mark failed