### PR TITLE
perf: cut initial-build agent loop latency

### DIFF
--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -423,6 +423,66 @@ function shouldEarlyStopOnTodos(
   return actionable.every((todo) => todo.status === 'completed');
 }
 
+/**
+ * Operation-aware Write/Edit budget. Once enough implementation tools land,
+ * stop even if TodoWrite never succeeded — the main latency killer on docs/sites
+ * was 40+ turns of polish after the app was already usable.
+ */
+function resolveImplementationToolBudget(operationType?: string): number {
+  switch (operationType) {
+    case 'autofix':
+      return 6;
+    case 'focused-edit':
+      return 5;
+    case 'enhancement':
+      return 12;
+    case 'continuation':
+      return 10;
+    case 'initial-build':
+    default:
+      return 14;
+  }
+}
+
+function isVerificationCommand(command: unknown): boolean {
+  if (typeof command !== 'string' || !command.trim()) return false;
+  const c = command.toLowerCase();
+  // Match common one-shot verify commands; avoid matching long-running dev servers.
+  if (/\b(dev|start|serve)\b/.test(c) && !/\b(build|typecheck|tsc|lint|test)\b/.test(c)) {
+    return false;
+  }
+  return (
+    /\bnpm\s+run\s+build\b/.test(c) ||
+    /\bpnpm\s+(run\s+)?build\b/.test(c) ||
+    /\byarn\s+(run\s+)?build\b/.test(c) ||
+    /\bbun\s+run\s+build\b/.test(c) ||
+    /\bnpm\s+run\s+typecheck\b/.test(c) ||
+    /\bpnpm\s+(run\s+)?typecheck\b/.test(c) ||
+    /\byarn\s+(run\s+)?typecheck\b/.test(c) ||
+    /\btsc\b/.test(c) ||
+    /\bnext\s+build\b/.test(c) ||
+    /\bvite\s+build\b/.test(c)
+  );
+}
+
+/**
+ * After real files landed and one verification command completed, stop.
+ * Does not require TodoWrite success.
+ */
+function shouldEarlyStopAfterVerification(options: {
+  implemented: boolean;
+  uniqueFilesModified: number;
+  verificationPasses: number;
+  minFiles?: number;
+}): boolean {
+  const minFiles = options.minFiles ?? 3;
+  return (
+    options.implemented &&
+    options.uniqueFilesModified >= minFiles &&
+    options.verificationPasses >= 1
+  );
+}
+
 function isAbortLikeError(error: unknown): boolean {
   if (!error) return false;
   if (typeof error === 'object') {
@@ -2515,7 +2575,8 @@ export async function startRunner(options: RunnerOptions = {}) {
         fileLog.info("Agent:", command.payload?.agent);
         fileLog.info("Template:", command.payload?.template);
 
-        // Early-stop is intentional success (todos done after implementation).
+        // Early-stop is intentional success (todos done after implementation,
+        // write budget hit, or one verification pass after real work).
         // Hoisted so abort/cancel/max-turns errors can still complete the build cleanly.
         let earlyStopTriggered = false;
         let earlyStopReason: string | undefined;
@@ -2524,6 +2585,11 @@ export async function startRunner(options: RunnerOptions = {}) {
         const completedTodos: string[] = [];
         let latestTodos: TrackedTodo[] = [];
         let implementedViaTools = false;
+        let implementationToolCount = 0;
+        let verificationPassCount = 0;
+        const pendingVerificationToolIds = new Set<string>();
+        const operationTypeForBudget = command.payload?.operationType || 'initial-build';
+        const implementationToolBudget = resolveImplementationToolBudget(operationTypeForBudget);
 
         try {
           loggedFirstChunk = false;
@@ -2753,6 +2819,32 @@ export async function startRunner(options: RunnerOptions = {}) {
               // ignore repeated abort
             }
           };
+
+          const maybeStopOnImplementationBudget = async () => {
+            if (implementationToolCount >= implementationToolBudget) {
+              await requestEarlyStop(
+                `implementation tool budget reached (${implementationToolCount}/${implementationToolBudget})`,
+              );
+              return true;
+            }
+            return false;
+          };
+
+          const maybeStopAfterVerification = async () => {
+            if (
+              shouldEarlyStopAfterVerification({
+                implemented: implementedViaTools,
+                uniqueFilesModified: filesModified.size,
+                verificationPasses: verificationPassCount,
+              })
+            ) {
+              await requestEarlyStop(
+                `verification complete after implementation (${filesModified.size} files, ${verificationPassCount} verify pass)`,
+              );
+              return true;
+            }
+            return false;
+          };
           
           while (true) {
             if (earlyStopTriggered) {
@@ -2932,6 +3024,33 @@ export async function startRunner(options: RunnerOptions = {}) {
 
                     if (isImplementationTool(toolName)) {
                       implementedViaTools = true;
+                      implementationToolCount += 1;
+
+                      const input = block.input as { file_path?: string; filePath?: string } | undefined;
+                      const filePath = input?.file_path || input?.filePath;
+                      if (filePath) {
+                        const relativePath = filePath.includes('/')
+                          ? filePath.split('/').slice(-2).join('/')
+                          : filePath;
+                        filesModified.add(relativePath);
+                      }
+
+                      if (!(await maybeStopOnImplementationBudget())) {
+                        if (shouldEarlyStopOnTodos(latestTodos, { implemented: true })) {
+                          await requestEarlyStop(
+                            `implementation landed and ${latestTodos.length} todos already complete`,
+                          );
+                        }
+                      }
+                    }
+
+                    if (
+                      typeof toolName === 'string' &&
+                      /^bash$/i.test(toolName) &&
+                      typeof toolId === 'string' &&
+                      isVerificationCommand((block.input as { command?: string } | undefined)?.command)
+                    ) {
+                      pendingVerificationToolIds.add(toolId);
                     }
                     
                     if (DEBUG_BUILD) {
@@ -2963,6 +3082,15 @@ export async function startRunner(options: RunnerOptions = {}) {
                           failed: Boolean(isError),
                         });
                         timingContext.activeToolTimings.delete(toolId);
+                      }
+
+                      // Soft-stop after a successful one-shot verify when files already landed.
+                      if (pendingVerificationToolIds.has(toolId)) {
+                        pendingVerificationToolIds.delete(toolId);
+                        if (!isError) {
+                          verificationPassCount += 1;
+                          await maybeStopAfterVerification();
+                        }
                       }
                     }
 
@@ -3059,10 +3187,13 @@ export async function startRunner(options: RunnerOptions = {}) {
 
                 if (isImplementationTool(toolEvent.toolName)) {
                   implementedViaTools = true;
+                  // Budget counting happens on the raw tool_use path to avoid double-count.
                   if (shouldEarlyStopOnTodos(latestTodos, { implemented: true })) {
                     await requestEarlyStop(
                       `implementation landed and ${latestTodos.length} todos already complete`,
                     );
+                  } else {
+                    await maybeStopOnImplementationBudget();
                   }
                 }
               }

--- a/apps/runner/src/lib/native-claude-sdk.ts
+++ b/apps/runner/src/lib/native-claude-sdk.ts
@@ -210,35 +210,32 @@ function buildPromptWithImages(prompt: string, messageParts?: MessagePart[]): st
  * Operation-aware turn budgets. Production builds were spending most wall time
  * in model turns (not tools); caps prevent long exploratory loops while still
  * leaving headroom for real multi-file work.
+ *
+ * Initial builds are intentionally tighter: runner-side write-budget early-stop
+ * and one-shot verify prompts should finish most apps well under this ceiling.
  */
 export function resolveClaudeMaxTurns(operationType?: string): number {
   switch (operationType) {
     case 'autofix':
-      return 20;
+      return 18;
     case 'focused-edit':
-      return 15;
+      return 12;
     case 'enhancement':
-      return 35;
+      return 28;
     case 'continuation':
-      return 30;
+      return 24;
     case 'initial-build':
     default:
-      // Large multi-page docs/sites often need more than 40 turns.
-      // Soft-complete still kicks in if the budget is exhausted with work landed.
-      return 60;
+      return 32;
   }
 }
 
 /**
- * Build tool surface:
- * - coding tools for implementation
- * - TodoWrite for native build progress tracking
- * - WebSearch/WebFetch for docs/context lookup
- *
- * Task stays disallowed: it spawns nested agent loops and is not used for
- * Hatchway progress tracking (TodoWrite is).
+ * Core coding tools always available during builds.
+ * Web tools are optional and disabled on initial-build (local template +
+ * manifest should be enough; web lookups add slow multi-second turns).
  */
-const CLAUDE_BUILD_TOOLS = [
+const CLAUDE_CORE_BUILD_TOOLS = [
   'Bash',
   'Read',
   'Write',
@@ -246,6 +243,9 @@ const CLAUDE_BUILD_TOOLS = [
   'Glob',
   'Grep',
   'TodoWrite',
+] as const;
+
+const CLAUDE_WEB_TOOLS = [
   'WebSearch',
   'WebFetch',
 ] as const;
@@ -257,6 +257,23 @@ const CLAUDE_DISALLOWED_TOOLS = [
   'Skill',
   'NotebookEdit',
 ] as const;
+
+export function resolveClaudeBuildTools(operationType?: string): string[] {
+  // Initial builds should stay on-template. Web is useful for later edits
+  // when the user asks about external APIs/docs.
+  if (!operationType || operationType === 'initial-build') {
+    return [...CLAUDE_CORE_BUILD_TOOLS];
+  }
+  return [...CLAUDE_CORE_BUILD_TOOLS, ...CLAUDE_WEB_TOOLS];
+}
+
+export function resolveClaudeDisallowedTools(operationType?: string): string[] {
+  const denied: string[] = [...CLAUDE_DISALLOWED_TOOLS];
+  if (!operationType || operationType === 'initial-build') {
+    denied.push(...CLAUDE_WEB_TOOLS);
+  }
+  return denied;
+}
 
 export interface NativeClaudeQueryOptions {
   maxTurns?: number;
@@ -279,6 +296,8 @@ export function createNativeClaudeQuery(
 ) {
   const resolvedMaxTurns =
     queryOptions.maxTurns ?? resolveClaudeMaxTurns(queryOptions.operationType);
+  const resolvedTools = resolveClaudeBuildTools(queryOptions.operationType);
+  const resolvedDisallowedTools = resolveClaudeDisallowedTools(queryOptions.operationType);
 
   return async function* nativeClaudeQuery(
     prompt: string,
@@ -293,6 +312,7 @@ export function createNativeClaudeQuery(
     debugLog(`[runner] [native-sdk] Working dir: ${workingDirectory}\n`);
     debugLog(`[runner] [native-sdk] Prompt length: ${prompt.length}\n`);
     debugLog(`[runner] [native-sdk] maxTurns: ${resolvedMaxTurns} (op=${queryOptions.operationType ?? 'default'})\n`);
+    debugLog(`[runner] [native-sdk] tools: ${resolvedTools.join(',')}\n`);
 
     // Build combined system prompt
     const systemPromptSegments: string[] = [CLAUDE_SYSTEM_PROMPT.trim()];
@@ -347,9 +367,10 @@ export function createNativeClaudeQuery(
         // Enable SDK debug logging only when explicitly diagnosing the SDK.
         ...(process.env.DEBUG_SKILLS === '1' ? { DEBUG_CLAUDE_AGENT_SDK: '1' } : {}),
       },
-      // Coding + TodoWrite progress + web research. Task/MCP/plan tools stay off.
-      tools: [...CLAUDE_BUILD_TOOLS],
-      disallowedTools: [...CLAUDE_DISALLOWED_TOOLS],
+      // Coding + TodoWrite progress. Web tools only outside initial-build.
+      // Task/MCP/plan tools stay off.
+      tools: resolvedTools,
+      disallowedTools: resolvedDisallowedTools,
       // Pass abort controller for cancellation support
       // NOTE: There is a known bug in the Claude Agent SDK where AbortController
       // signals are not fully respected. When abort() is called, the SDK may

--- a/apps/runner/src/lib/permissions/project-scoped-handler.ts
+++ b/apps/runner/src/lib/permissions/project-scoped-handler.ts
@@ -49,7 +49,7 @@ export function createProjectScopedPermissionHandler(projectDirectory: string): 
         behavior: 'deny',
         message:
           `Tool "${toolName}" is disabled for Hatchway builds. ` +
-          'Use Bash/Read/Write/Edit/Glob/Grep, TodoWrite for progress, and WebSearch/WebFetch for docs.',
+          'Use Bash/Read/Write/Edit/Glob/Grep and TodoWrite for progress. Prefer local files over web lookups.',
         interrupt: false,
       };
     }

--- a/packages/agent-core/src/lib/agents/claude-strategy.ts
+++ b/packages/agent-core/src/lib/agents/claude-strategy.ts
@@ -142,11 +142,12 @@ function buildFullPrompt(context: AgentStrategyContext, basePrompt: string): str
 CRITICAL: The template has already been prepared in ${context.workingDirectory}. Do not scaffold a new project.
 
 ## Speed Rules
-1. First tool call: TodoWrite with ≤8 concrete implementation todos, one in_progress.
+1. First tool call: TodoWrite with ≤6 concrete implementation todos, one in_progress.
 2. Implement with Write/Edit next — do not spend early turns only researching.
-3. Use WebSearch/WebFetch only for missing external docs/API details; max a couple lookups unless blocked.
-4. One dependency install after package.json changes; one build/typecheck; fix only real failures.
-5. Mark todos completed as you finish them. When all are completed and validation is clean, stop immediately — no extra polish turns.`;
+3. Do not use WebSearch/WebFetch on initial builds unless you are blocked without external docs.
+4. One dependency install after package.json changes; ONE build/typecheck; fix blocking errors once; then stop.
+5. Ship the minimum coherent app that satisfies the request. Prefer fewer files over exhaustive page sets.
+6. Mark todos completed as you finish them. When implementation + one verification pass are done, stop immediately — no polish turns.`;
 }
 
 const claudeStrategy: AgentStrategy = {

--- a/packages/agent-core/src/lib/prompts.ts
+++ b/packages/agent-core/src/lib/prompts.ts
@@ -12,14 +12,14 @@ export const CLAUDE_SYSTEM_PROMPT = `You are an elite coding assistant specializ
 
 - Begin project work immediately. Do not load skills or plugins, and do not enter plan mode unless the user explicitly asks for a plan.
 - Read the relevant existing files before editing. Preserve working scaffold behavior and customize it instead of generating a replacement app.
-- First action on multi-step work: call TodoWrite with a short plan (4-8 items, one \`in_progress\`). Then implement immediately. Emit the complete list on every update until all items are \`completed\`.
+- First action on multi-step work: call TodoWrite with a short plan (3-6 items, one \`in_progress\`). Then implement immediately. Emit the complete list on every update until all items are \`completed\`.
 - Do not call Task, Skill, or MCP tools.
-- Use WebSearch/WebFetch only when you need external docs or API context you do not already have. Prefer local files and the project manifest first.
-- Prefer Write/Edit over long exploratory Bash sessions. Avoid open-ended research loops.
+- Prefer local files and the project manifest. Avoid web lookups on initial builds unless blocked without external docs.
+- Prefer Write/Edit over long exploratory Bash sessions. Avoid open-ended research loops and unrequested extra pages/features.
 - Inspect package files first, make all code and dependency-manifest changes, then install dependencies together once. For npm, prefer \`npm install --prefer-offline --no-audit --no-fund\`. Do not repeatedly install packages one at a time.
 - For UI work, produce a coherent, responsive, accessible design with intentional typography, spacing, hierarchy, and interaction states. Avoid generic placeholder styling and unnecessary rewrites.
-- Run the project's build or typecheck after implementation. Fix errors and rerun until clean. Only start a dev server once, at the end when runtime verification is useful, and stop it afterward.
-- When every TodoWrite item is completed and validation is clean, stop. Do not keep polishing, researching alternatives, or adding unrequested scope.
+- After implementation, run ONE build or typecheck. Fix only blocking errors once, then stop. Do not start a long-running dev server.
+- When the requested app works and todos are done, stop immediately. No polish passes, no alternate designs, no unrequested scope.
 - Work quietly between progress updates. Finish with a concise summary of what changed and what validation passed.
 
 ## Plan Mode


### PR DESCRIPTION
## Summary
Latest builds still spent ~7 minutes almost entirely in the agent loop (44 turns, 21 Writes). TodoWrite early-stop rarely fired, web tools added multi-second stalls, and verify-forever prompts kept the model polishing.

## Changes
- **Write/Edit budget early-stop** (14 on initial-build) independent of TodoWrite
- **Verification early-stop** after one successful build/typecheck when files already landed
- **No WebSearch/WebFetch on initial-build**
- **maxTurns**: initial 60→32, enhancement 35→28, autofix/focused tighter
- **Prompts**: one-shot verify, ship minimum coherent app, no polish loops

## Expected impact
For docs/simple apps that previously did 21+ Writes / 40+ turns, expect finish near the write budget (~14 implementation tools) instead of running to 40-60 turns. Target is cutting multi-minute polish tails, not eliminating all model time.

## Test plan
- [ ] Restart local runner on this release
- [ ] Run a simple docs/site initial build
- [ ] Confirm metrics show earlyStopReason like implementation tool budget or verification complete
- [ ] Confirm status=completed and usable preview
- [ ] Confirm enhancement builds still have web tools available
