### PR TITLE
fix: sandbox tar sync + live activity feed

### DIFF
--- a/apps/hatchway/src/app/api/build-events/route.ts
+++ b/apps/hatchway/src/app/api/build-events/route.ts
@@ -501,19 +501,15 @@ export async function POST(request: Request) {
             set: { input: event.input ?? null, state: 'input-available', updatedAt: timestamp },
           });
 
-          // WebSocket: Broadcast tool-input-available for planning phase tools AND skill loads
-          // This enables the shimmer animation to show the active tool being used
-          // Execution phase tools (todoIndex >= 0) only broadcast on completion
-          // Exception: SkillLoad events always broadcast immediately so frontend can show skill loading state
-          if (todoIndex < 0 || event.toolName === 'SkillLoad') {
-            buildWebSocketServer.broadcastToolCall(projectId, sessionId, {
-              id: toolCallId,
-              name: event.toolName,
-              todoIndex,
-              input: event.input ?? undefined,
-              state: 'input-available',
-            });
-          }
+          // Broadcast tool starts immediately so the activity feed feels live.
+          // (Previously execution-phase tools only broadcast on completion.)
+          buildWebSocketServer.broadcastToolCall(projectId, sessionId, {
+            id: toolCallId,
+            name: event.toolName,
+            todoIndex,
+            input: event.input ?? undefined,
+            state: 'input-available',
+          });
         }
         break;
       }

--- a/apps/hatchway/src/app/api/runner/events/route.ts
+++ b/apps/hatchway/src/app/api/runner/events/route.ts
@@ -811,11 +811,75 @@ IMPORTANT:
           }
           case 'build-stream':
             break;
-          case 'error': {
+          case 'status': {
+            // Non-fatal progress note (sandbox provisioning, etc.)
+            const statusMessage =
+              'message' in event && typeof event.message === 'string'
+                ? event.message
+                : 'Status update';
+            console.log(`[events] ℹ️ Status for ${projectId}: ${statusMessage}`);
+            buildWebSocketServer.broadcastActivityStatus(projectId, '', {
+              message: statusMessage,
+              phase: 'phase' in event && typeof event.phase === 'string' ? event.phase : undefined,
+              level: 'info',
+            });
+            break;
+          }
+          case 'preview-failed': {
+            // Build succeeded but sandbox/preview provision failed.
+            // Keep generation session completed; only mark preview/dev server failed.
+            const previewError =
+              'error' in event && typeof event.error === 'string'
+                ? event.error
+                : 'Preview provision failed';
+            const friendly = `Preview failed: ${previewError}`.slice(0, 500);
+            console.log(`[events] ⚠️ Preview failed for ${projectId}: ${previewError.slice(0, 200)}`);
+
             const [updated] = await db.update(projects)
               .set({
                 devServerStatus: 'failed',
-                errorMessage: event.error,
+                errorMessage: friendly,
+                lastActivityAt: new Date(),
+              })
+              .where(eq(projects.id, projectId))
+              .returning();
+            if (updated) emitProjectUpdateFromData(projectId, updated);
+
+            buildWebSocketServer.broadcastActivityStatus(projectId, '', {
+              message: friendly,
+              phase: 'phase' in event && typeof event.phase === 'string' ? event.phase : 'sandbox-sync',
+              level: 'error',
+            });
+            break;
+          }
+          case 'error': {
+            const errText =
+              'error' in event && typeof event.error === 'string' ? event.error : 'Unknown error';
+            // Sandbox sync used to emit generic "error"; treat those as preview failures
+            // so a successful build is not shown as "Build failed".
+            if (/sandbox sync failed/i.test(errText)) {
+              const friendly = `Preview failed: ${errText}`.slice(0, 500);
+              const [updated] = await db.update(projects)
+                .set({
+                  devServerStatus: 'failed',
+                  errorMessage: friendly,
+                  lastActivityAt: new Date(),
+                })
+                .where(eq(projects.id, projectId))
+                .returning();
+              if (updated) emitProjectUpdateFromData(projectId, updated);
+              buildWebSocketServer.broadcastActivityStatus(projectId, '', {
+                message: friendly,
+                phase: 'sandbox-sync',
+                level: 'error',
+              });
+              break;
+            }
+
+            const [updated] = await db.update(projects)
+              .set({
+                devServerStatus: 'failed',
+                errorMessage: errText,
                 lastActivityAt: new Date(),
               })
               .where(eq(projects.id, projectId))

--- a/apps/hatchway/src/app/page.tsx
+++ b/apps/hatchway/src/app/page.tsx
@@ -3070,12 +3070,30 @@ function HomeContent() {
                               })()}
                             </div>
                           )}
+                          {/* Preview provision failure (build may have succeeded) */}
+                          {currentProject.devServerStatus === "failed" &&
+                            currentProject.status !== "failed" &&
+                            currentProject.errorMessage &&
+                            /preview failed|sandbox sync failed/i.test(currentProject.errorMessage) && (
+                            <div className="mt-2 p-2 bg-amber-500/10 border border-amber-500/30 rounded-lg">
+                              <div className="flex items-start justify-between gap-2">
+                                <div className="flex-1">
+                                  <p className="text-xs font-medium text-amber-300">Preview Failed</p>
+                                  <p className="text-xs text-amber-200/80 mt-0.5">{currentProject.errorMessage}</p>
+                                </div>
+                              </div>
+                            </div>
+                          )}
                           {/* Error message and retry button */}
                           {currentProject.status === "failed" && (
                             <div className="mt-2 p-2 bg-[#FF45A8]/10 border border-[#FF45A8]/30 rounded-lg">
                               <div className="flex items-start justify-between gap-2">
                                 <div className="flex-1">
-                                  <p className="text-xs font-medium text-[#FF45A8]">Generation Failed</p>
+                                  <p className="text-xs font-medium text-[#FF45A8]">
+                                    {currentProject.errorMessage && /preview failed|sandbox sync failed/i.test(currentProject.errorMessage)
+                                      ? 'Preview Failed'
+                                      : 'Generation Failed'}
+                                  </p>
                                   {currentProject.errorMessage && (
                                     <p className="text-xs text-[#FF70BC]/80 mt-0.5">{currentProject.errorMessage}</p>
                                   )}

--- a/apps/hatchway/src/components/BuildProgress/ActivityFeed.tsx
+++ b/apps/hatchway/src/components/BuildProgress/ActivityFeed.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { CheckCircle2, Circle, Loader2, AlertTriangle, Info, MessageSquare } from 'lucide-react';
+import type { ActivityItem } from '@/types/generation';
+
+interface ActivityFeedProps {
+  items: ActivityItem[];
+  isActive?: boolean;
+  emptyLabel?: string;
+}
+
+function formatTime(ts: Date | string | number | undefined): string {
+  if (!ts) return '';
+  const d = ts instanceof Date ? ts : new Date(ts);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function StatusIcon({ item }: { item: ActivityItem }) {
+  if (item.status === 'running') {
+    return <Loader2 className="h-3.5 w-3.5 text-theme-primary animate-spin flex-shrink-0" />;
+  }
+  if (item.status === 'error') {
+    return <AlertTriangle className="h-3.5 w-3.5 text-red-400 flex-shrink-0" />;
+  }
+  if (item.status === 'success' || item.status === 'completed') {
+    return <CheckCircle2 className="h-3.5 w-3.5 text-green-500 dark:text-green-400 flex-shrink-0" />;
+  }
+  if (item.status === 'warning') {
+    return <AlertTriangle className="h-3.5 w-3.5 text-amber-400 flex-shrink-0" />;
+  }
+  if (item.kind === 'text') {
+    return <MessageSquare className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />;
+  }
+  if (item.kind === 'status') {
+    return <Info className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />;
+  }
+  return <Circle className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />;
+}
+
+function kindPrefix(item: ActivityItem): string {
+  if (item.kind === 'tool') return '›';
+  if (item.kind === 'todo') return '•';
+  if (item.kind === 'text') return '·';
+  return '·';
+}
+
+export function ActivityFeed({
+  items,
+  isActive = false,
+  emptyLabel = 'Waiting for agent activity…',
+}: ActivityFeedProps) {
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
+
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+      stickToBottomRef.current = distance < 48;
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el || !stickToBottomRef.current) return;
+    el.scrollTop = el.scrollHeight;
+  }, [items.length, items[items.length - 1]?.id, items[items.length - 1]?.status]);
+
+  if (!items.length) {
+    return (
+      <div className="px-4 py-6 text-sm text-muted-foreground flex items-center gap-2">
+        {isActive ? <Loader2 className="h-4 w-4 animate-spin text-theme-primary" /> : null}
+        <span className={isActive ? 'shimmer-text' : ''}>{emptyLabel}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={scrollerRef}
+      className="max-h-[360px] overflow-y-auto px-3 py-2 font-mono text-xs leading-relaxed"
+    >
+      <AnimatePresence initial={false}>
+        {items.map((item) => {
+          const isError = item.status === 'error';
+          const isRunning = item.status === 'running';
+          return (
+            <motion.div
+              key={item.id}
+              initial={{ opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              className={`flex items-start gap-2 py-1 px-1 rounded ${
+                isError
+                  ? 'bg-red-500/5 text-red-300'
+                  : isRunning
+                    ? 'bg-theme-primary/5'
+                    : 'text-muted-foreground'
+              }`}
+            >
+              <span className="text-muted-foreground/70 w-3 flex-shrink-0 pt-0.5">
+                {kindPrefix(item)}
+              </span>
+              <StatusIcon item={item} />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-baseline gap-2 min-w-0">
+                  <span
+                    className={`truncate ${
+                      item.kind === 'tool'
+                        ? isRunning
+                          ? 'shimmer-text text-foreground'
+                          : 'text-foreground/90'
+                        : item.kind === 'todo'
+                          ? 'text-foreground font-medium'
+                          : isError
+                            ? 'text-red-300'
+                            : 'text-foreground/80'
+                    }`}
+                  >
+                    {item.label}
+                  </span>
+                  {item.detail && item.kind !== 'status' && (
+                    <span className="truncate text-muted-foreground/80">{item.detail}</span>
+                  )}
+                </div>
+                {item.kind === 'status' && item.detail && (
+                  <div className="text-[10px] text-muted-foreground/70 mt-0.5">{item.detail}</div>
+                )}
+              </div>
+              <span className="text-[10px] text-muted-foreground/50 flex-shrink-0 tabular-nums pt-0.5">
+                {formatTime(item.timestamp)}
+              </span>
+            </motion.div>
+          );
+        })}
+      </AnimatePresence>
+      {isActive && (
+        <div className="flex items-center gap-2 py-1.5 px-1 text-muted-foreground">
+          <span className="w-3" />
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-theme-primary" />
+          <span className="shimmer-text">working…</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/hatchway/src/components/BuildProgress/index.tsx
+++ b/apps/hatchway/src/components/BuildProgress/index.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { motion, AnimatePresence } from 'framer-motion';
-import { Loader2, CheckCircle2, ChevronDown, ChevronUp, Square } from 'lucide-react';
+import { Loader2, CheckCircle2, ChevronDown, ChevronUp, Square, AlertTriangle } from 'lucide-react';
 import { useState, useEffect, useMemo, useRef } from 'react';
-import type { GenerationState, TodoItem } from '@/types/generation';
+import type { GenerationState, TodoItem, ActivityItem, ToolCall } from '@/types/generation';
 import { BuildHeader } from './BuildHeader';
 import { TodoList } from './TodoList';
 import { PlanningPhase } from './PlanningPhase';
 import { PhaseSection } from './PhaseSection';
+import { ActivityFeed } from './ActivityFeed';
 
 interface BuildProgressProps {
   state: GenerationState;
@@ -23,14 +24,123 @@ interface BuildProgressProps {
   } | null;
 }
 
+function getToolResource(tool: ToolCall): string {
+  if (!tool.input) return '';
+  const input = tool.input as Record<string, unknown>;
+  if (typeof input.skillName === 'string') return input.skillName;
+  if (typeof input.file_path === 'string') {
+    const path = input.file_path;
+    const match = path.match(/hatchway-workspace\/[^/]+\/(.+)$/);
+    return match ? match[1] : path.split('/').slice(-2).join('/');
+  }
+  if (typeof input.path === 'string') {
+    const path = input.path;
+    const match = path.match(/hatchway-workspace\/[^/]+\/(.+)$/);
+    return match ? match[1] : path.split('/').slice(-2).join('/');
+  }
+  if (typeof input.command === 'string') {
+    return input.command.length > 80 ? `${input.command.slice(0, 80)}…` : input.command;
+  }
+  if (typeof input.query === 'string') {
+    return input.query.length > 80 ? `${input.query.slice(0, 80)}…` : input.query;
+  }
+  if (typeof input.pattern === 'string') return input.pattern;
+  return '';
+}
+
+/** Reconstruct a chronological feed when live activityFeed is empty (reconnect / history). */
+function deriveActivityFeed(state: GenerationState): ActivityItem[] {
+  if (state.activityFeed && state.activityFeed.length > 0) {
+    return state.activityFeed;
+  }
+
+  const items: ActivityItem[] = [];
+
+  for (const tool of state.planningTools || []) {
+    if (tool.name === 'TodoWrite') continue;
+    items.push({
+      id: `tool-${tool.id}`,
+      kind: 'tool',
+      timestamp: tool.startTime || state.startTime,
+      label: tool.name,
+      detail: getToolResource(tool),
+      status:
+        tool.state === 'error'
+          ? 'error'
+          : tool.state === 'output-available'
+            ? 'completed'
+            : 'running',
+      toolName: tool.name,
+      toolId: tool.id,
+      todoIndex: -1,
+    });
+  }
+
+  (state.todos || []).forEach((todo, index) => {
+    if (todo.status === 'pending') return;
+    items.push({
+      id: `todo-derived-${index}`,
+      kind: 'todo',
+      timestamp: state.startTime,
+      label: todo.status === 'in_progress' ? todo.activeForm : todo.content,
+      status: todo.status === 'completed' ? 'completed' : 'running',
+      todoIndex: index,
+    });
+
+    for (const tool of state.toolsByTodo?.[index] || []) {
+      if (tool.name === 'TodoWrite') continue;
+      items.push({
+        id: `tool-${tool.id}`,
+        kind: 'tool',
+        timestamp: tool.startTime || state.startTime,
+        label: tool.name,
+        detail: getToolResource(tool),
+        status:
+          tool.state === 'error'
+            ? 'error'
+            : tool.state === 'output-available'
+              ? 'completed'
+              : 'running',
+        toolName: tool.name,
+        toolId: tool.id,
+        todoIndex: index,
+      });
+    }
+  });
+
+  if (state.buildSummary) {
+    items.push({
+      id: 'text-summary-derived',
+      kind: 'text',
+      timestamp: state.endTime || new Date(),
+      label: state.buildSummary.slice(0, 200),
+      status: 'info',
+    });
+  }
+
+  if (state.previewError) {
+    items.push({
+      id: 'status-preview-error-derived',
+      kind: 'status',
+      timestamp: state.endTime || new Date(),
+      label: state.previewError,
+      status: 'error',
+    });
+  }
+
+  return items;
+}
+
 // Build Complete Summary component - shows collapsed todos
 function BuildCompleteSummary({
   todos,
   buildSummary,
+  previewError,
   onExpand,
 }: {
   todos: TodoItem[];
   buildSummary?: string;
+  previewError?: string;
   onExpand: () => void;
 }) {
   const [showTodos, setShowTodos] = useState(false);
@@ -50,18 +160,27 @@ function BuildCompleteSummary({
           </p>
         )}
 
+        {previewError && (
+          <div className="mb-3 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-2 text-xs text-amber-200">
+            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 flex-shrink-0" />
+            <span>{previewError}</span>
+          </div>
+        )}
+
         {/* Collapsible todos section */}
-        <button
-          onClick={() => setShowTodos(!showTodos)}
-          className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
-        >
-          {showTodos ? (
-            <ChevronUp className="w-3 h-3" />
-          ) : (
-            <ChevronDown className="w-3 h-3" />
-          )}
-          <span>{todos.length} tasks completed</span>
-        </button>
+        {todos.length > 0 && (
+          <button
+            onClick={() => setShowTodos(!showTodos)}
+            className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {showTodos ? (
+              <ChevronUp className="w-3 h-3" />
+            ) : (
+              <ChevronDown className="w-3 h-3" />
+            )}
+            <span>{todos.length} tasks completed</span>
+          </button>
+        )}
 
         <AnimatePresence>
           {showTodos && (
@@ -82,6 +201,13 @@ function BuildCompleteSummary({
             </motion.div>
           )}
         </AnimatePresence>
+
+        <button
+          onClick={onExpand}
+          className="mt-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Show activity
+        </button>
       </div>
     </div>
   );
@@ -97,8 +223,8 @@ export default function BuildProgress({
 }: BuildProgressProps) {
   // ALWAYS call hooks first (React rules!)
   const [isCardExpanded, setIsCardExpanded] = useState(!defaultCollapsed);
+  const [showTodoFallback, setShowTodoFallback] = useState(false);
   const todoListRef = useRef<HTMLDivElement>(null);
-  const activeTodoRef = useRef<HTMLDivElement>(null);
 
   // Calculate totals across both phases
   // Note: templateTodos and currentPhase are new fields added to GenerationState
@@ -113,8 +239,11 @@ export default function BuildProgress({
   const buildCompleted = buildTodos.filter((t) => t.status === 'completed').length;
   const completed = templateCompleted + buildCompleted;
   const total = templateTodos.length + buildTodos.length;
-  const progress = total > 0 ? (completed / total) * 100 : 0;
-  const isComplete = progress === 100 && !state?.isActive;
+  const activityItems = useMemo(() => (state ? deriveActivityFeed(state) : []), [state]);
+  const hasActivity = activityItems.length > 0;
+  // Progress prefers todos when present; otherwise activity-based indeterminate progress while active
+  const progress = total > 0 ? (completed / total) * 100 : state?.isActive ? 15 : hasActivity ? 100 : 0;
+  const isComplete = Boolean(state && !state.isActive && (total === 0 ? hasActivity || !!state.buildSummary : completed === total));
   
   // Determine phase states
   const templatePhaseComplete = templateTodos.length > 0 && templateTodos.every((t) => t.status === 'completed');
@@ -126,20 +255,14 @@ export default function BuildProgress({
   useEffect(() => {
     console.log('🔍 BuildProgress state update:', {
       todosLength: state?.todos?.length || 0,
+      activityLength: activityItems.length,
       isActive: state?.isActive,
       activeTodoIndex: state?.activeTodoIndex,
       agentId: state?.agentId,
       claudeModelId: state?.claudeModelId,
       projectName: state?.projectName,
     });
-
-    if (state?.toolsByTodo) {
-      const toolCounts = Object.keys(state.toolsByTodo)
-        .map((idx) => `todo${idx}: ${state.toolsByTodo[Number(idx)]?.length || 0} tools`)
-        .join(', ');
-      console.log('   📊 toolsByTodo:', toolCounts || 'empty');
-    }
-  }, [state]);
+  }, [state, activityItems.length]);
 
   // Auto-collapse card when build completes (only if not defaultCollapsed)
   useEffect(() => {
@@ -149,11 +272,10 @@ export default function BuildProgress({
     }
   }, [isComplete, defaultCollapsed]);
 
-  // Auto-scroll to active todo when it changes
+  // Auto-scroll to active todo when it changes (todo fallback view)
   useEffect(() => {
-    if (!state?.isActive || state.activeTodoIndex < 0) return;
+    if (!state?.isActive || state.activeTodoIndex < 0 || !showTodoFallback) return;
 
-    // Small delay to let the DOM update
     const timer = setTimeout(() => {
       const activeElement = document.querySelector(`[data-todo-index="${state.activeTodoIndex}"]`);
       if (activeElement && todoListRef.current) {
@@ -162,22 +284,18 @@ export default function BuildProgress({
           block: 'nearest',
           inline: 'nearest',
         });
-        console.log(`📜 Auto-scrolled to active todo: ${state.activeTodoIndex}`);
       }
     }, 300);
 
     return () => clearTimeout(timer);
-  }, [state?.activeTodoIndex, state?.isActive]);
+  }, [state?.activeTodoIndex, state?.isActive, showTodoFallback]);
 
-  // Removed auto-switch logic - ONLY todo view now!
-
-  // ALL useMemo/useCallback MUST be before early returns
   const allTodosCompleted = useMemo(() => {
-    return state.todos?.length ? state.todos.every((todo) => todo.status === 'completed') : false;
-  }, [state.todos]);
+    return state?.todos?.length ? state.todos.every((todo) => todo.status === 'completed') : false;
+  }, [state?.todos]);
 
   // Validate state AFTER ALL hooks
-  if (!state || !state.todos || !Array.isArray(state.todos)) {
+  if (!state) {
     console.error('⚠️ Invalid generation state:', state);
     return (
       <div className="p-4 border border-red-500/30 rounded-lg bg-red-500/10">
@@ -194,8 +312,8 @@ export default function BuildProgress({
     );
   }
 
-  // Show planning phase ONLY if no todos yet (Claude is exploring/planning)
-  if (total === 0 && state.isActive) {
+  // Early planning shimmer only when we have no activity yet
+  if (!hasActivity && total === 0 && state.isActive) {
     return (
       <motion.div
         initial={{ opacity: 0, y: -20 }}
@@ -206,6 +324,27 @@ export default function BuildProgress({
           activePlanningTool={state.activePlanningTool}
           projectName={state.projectName}
         />
+        {onCancel && (
+          <div className="mt-4">
+            <button
+              onClick={onCancel}
+              disabled={isCancelling}
+              className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm text-gray-400 hover:text-red-400 transition-colors rounded-lg border border-white/10 hover:border-red-500/30 hover:bg-red-500/5 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isCancelling ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <span>Cancelling...</span>
+                </>
+              ) : (
+                <>
+                  <Square className="w-4 h-4" />
+                  <span>Stop Build</span>
+                </>
+              )}
+            </button>
+          </div>
+        )}
       </motion.div>
     );
   }
@@ -221,8 +360,8 @@ export default function BuildProgress({
         projectName={state.projectName}
         agentId={state.agentId}
         claudeModelId={state.claudeModelId}
-        completed={completed}
-        total={total}
+        completed={total > 0 ? completed : Math.min(activityItems.length, 1)}
+        total={total > 0 ? total : Math.max(activityItems.length, 1)}
         progress={progress}
         isComplete={isComplete}
         isActive={state.isActive}
@@ -235,12 +374,25 @@ export default function BuildProgress({
       {/* Content - Only show when expanded */}
       {isCardExpanded && (
         <>
-          {total > 0 ? (
+          <div className="flex items-center justify-between px-4 pt-2">
+            <p className="text-[11px] uppercase tracking-wide text-muted-foreground/70">
+              {showTodoFallback ? 'Tasks' : 'Activity'}
+            </p>
+            {total > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowTodoFallback((v) => !v)}
+                className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {showTodoFallback ? 'Show activity' : 'Show tasks'}
+              </button>
+            )}
+          </div>
+
+          {showTodoFallback && total > 0 ? (
             <div ref={todoListRef}>
-              {/* Two-phase display when template todos exist */}
               {templateTodos.length > 0 ? (
                 <>
-                  {/* Phase 1: Template Configuration */}
                   <PhaseSection
                     phase="template"
                     title="Template Setup"
@@ -249,8 +401,6 @@ export default function BuildProgress({
                     isActive={templatePhaseActive}
                     isComplete={templatePhaseComplete}
                   />
-                  
-                  {/* Phase 2: Application Build */}
                   {buildTodos.length > 0 && (
                     <PhaseSection
                       phase="build"
@@ -263,41 +413,49 @@ export default function BuildProgress({
                   )}
                 </>
               ) : (
-                /* Legacy single-phase display (no template phase) */
                 <TodoList
-                  todos={state.todos}
-                  toolsByTodo={state.toolsByTodo}
+                  todos={state.todos || []}
+                  toolsByTodo={state.toolsByTodo || {}}
                   activeTodoIndex={state.activeTodoIndex}
                   allTodosCompleted={allTodosCompleted}
                 />
               )}
-              
-              {/* Stop Build button - below the task list */}
-              {state.isActive && onCancel && (
-                <div className="px-4 pb-4">
-                  <button
-                    onClick={onCancel}
-                    disabled={isCancelling}
-                    className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm text-gray-400 hover:text-red-400 transition-colors rounded-lg border border-white/10 hover:border-red-500/30 hover:bg-red-500/5 disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {isCancelling ? (
-                      <>
-                        <Loader2 className="w-4 h-4 animate-spin" />
-                        <span>Cancelling...</span>
-                      </>
-                    ) : (
-                      <>
-                        <Square className="w-4 h-4" />
-                        <span>Stop Build</span>
-                      </>
-                    )}
-                  </button>
-                </div>
-              )}
             </div>
           ) : (
-            <div className="p-6 text-center text-gray-400 text-sm">
-              {state.isActive ? 'Initializing build...' : 'No tasks to display'}
+            <ActivityFeed
+              items={activityItems}
+              isActive={state.isActive}
+              emptyLabel={state.isActive ? 'Starting agent…' : 'No activity recorded'}
+            />
+          )}
+
+          {state.previewError && (
+            <div className="mx-4 mb-3 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-2 text-xs text-amber-200">
+              <AlertTriangle className="h-3.5 w-3.5 mt-0.5 flex-shrink-0" />
+              <span>{state.previewError}</span>
+            </div>
+          )}
+              
+          {/* Stop Build button - below the activity feed */}
+          {state.isActive && onCancel && (
+            <div className="px-4 pb-4">
+              <button
+                onClick={onCancel}
+                disabled={isCancelling}
+                className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm text-gray-400 hover:text-red-400 transition-colors rounded-lg border border-white/10 hover:border-red-500/30 hover:bg-red-500/5 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isCancelling ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    <span>Cancelling...</span>
+                  </>
+                ) : (
+                  <>
+                    <Square className="w-4 h-4" />
+                    <span>Stop Build</span>
+                  </>
+                )}
+              </button>
             </div>
           )}
         </>
@@ -306,8 +464,9 @@ export default function BuildProgress({
       {/* Build Complete Summary - show collapsed todos when build is done */}
       {isComplete && !isCardExpanded && (
         <BuildCompleteSummary
-          todos={state.todos}
+          todos={state.todos || []}
           buildSummary={state.buildSummary}
+          previewError={state.previewError}
           onExpand={() => setIsCardExpanded(true)}
         />
       )}

--- a/apps/hatchway/src/hooks/useBuildWebSocket.ts
+++ b/apps/hatchway/src/hooks/useBuildWebSocket.ts
@@ -9,7 +9,48 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import type { GenerationState } from '@/types/generation';
+import type { ActivityItem, GenerationState, ToolCall } from '@/types/generation';
+
+const ACTIVITY_FEED_MAX = 200;
+
+function getToolResourceLabel(tool: { name: string; input?: unknown }): string {
+  if (!tool.input) return '';
+  const input = tool.input as Record<string, unknown>;
+  if (typeof input.skillName === 'string') return input.skillName;
+  if (typeof input.file_path === 'string') {
+    const path = input.file_path;
+    const match = path.match(/hatchway-workspace\/[^/]+\/(.+)$/);
+    return match ? match[1] : path.split('/').slice(-2).join('/');
+  }
+  if (typeof input.path === 'string') {
+    const path = input.path;
+    const match = path.match(/hatchway-workspace\/[^/]+\/(.+)$/);
+    return match ? match[1] : path.split('/').slice(-2).join('/');
+  }
+  if (typeof input.command === 'string') {
+    return input.command.length > 80 ? `${input.command.slice(0, 80)}…` : input.command;
+  }
+  if (typeof input.query === 'string') {
+    return input.query.length > 80 ? `${input.query.slice(0, 80)}…` : input.query;
+  }
+  if (typeof input.pattern === 'string') return input.pattern;
+  if (typeof input.url === 'string') return input.url;
+  return '';
+}
+
+function upsertActivityItem(feed: ActivityItem[] | undefined, item: ActivityItem): ActivityItem[] {
+  const next = [...(feed || [])];
+  const existingIndex = next.findIndex((entry) => entry.id === item.id);
+  if (existingIndex >= 0) {
+    next[existingIndex] = { ...next[existingIndex], ...item, timestamp: next[existingIndex].timestamp };
+  } else {
+    next.push(item);
+  }
+  if (next.length > ACTIVITY_FEED_MAX) {
+    return next.slice(next.length - ACTIVITY_FEED_MAX);
+  }
+  return next;
+}
 
 interface WebSocketMessage {
   type: string;
@@ -260,10 +301,14 @@ export function useBuildWebSocket({
           isActive: true,
           startTime: new Date(),
           planningTools: [],
+          activityFeed: [],
         };
       }
       
       let newState = { ...prevState };
+      if (!newState.activityFeed) {
+        newState.activityFeed = [];
+      }
       
       for (const update of updates) {
         switch (update.type) {
@@ -280,11 +325,40 @@ export function useBuildWebSocket({
             if (buildStartData.projectId) {
               newState.projectId = buildStartData.projectId;
             }
+            newState.activityFeed = upsertActivityItem(newState.activityFeed, {
+              id: `status-build-started-${buildStartData.buildId || Date.now()}`,
+              kind: 'status',
+              timestamp: new Date(),
+              label: 'Build started',
+              status: 'info',
+            });
             // If this is an auto-fix build starting, clear the pending autofix state
             if (newState.isAutoFix) {
               setAutoFixState(null);
             }
             break;
+
+          case 'activity-status': {
+            const statusData = update.data as {
+              message?: string;
+              phase?: string;
+              level?: 'info' | 'success' | 'warning' | 'error';
+            };
+            const message = statusData.message || 'Status update';
+            const level = statusData.level || 'info';
+            newState.activityFeed = upsertActivityItem(newState.activityFeed, {
+              id: `status-${statusData.phase || 'general'}-${update.timestamp || Date.now()}`,
+              kind: 'status',
+              timestamp: new Date(update.timestamp || Date.now()),
+              label: message,
+              detail: statusData.phase,
+              status: level,
+            });
+            if (level === 'error' && /preview failed/i.test(message)) {
+              newState.previewError = message;
+            }
+            break;
+          }
 
           case 'autofix-started':
             // Auto-fix has been triggered - show immediate feedback
@@ -339,6 +413,21 @@ export function useBuildWebSocket({
                 newState.activePlanningTool = undefined;
               }
             }
+
+            const activeTodo =
+              mappedTodos[todosData.activeTodoIndex] ||
+              mappedTodos.find((t) => t.status === 'in_progress');
+            if (activeTodo) {
+              newState.activityFeed = upsertActivityItem(newState.activityFeed, {
+                id: `todo-${todosData.phase || 'build'}-${todosData.activeTodoIndex}-${activeTodo.content.slice(0, 40)}`,
+                kind: 'todo',
+                timestamp: new Date(),
+                label: activeTodo.status === 'in_progress' ? activeTodo.activeForm : activeTodo.content,
+                detail: todosData.phase === 'template' ? 'template' : 'build',
+                status: activeTodo.status === 'completed' ? 'completed' : 'running',
+                todoIndex: todosData.activeTodoIndex,
+              });
+            }
             break;
 
           case 'build-complete':
@@ -356,12 +445,27 @@ export function useBuildWebSocket({
               newState.buildSummary = completeData.summary;
               console.log(`[useBuildWebSocket] 📝 Set buildSummary on state`);
             }
+            newState.activityFeed = upsertActivityItem(newState.activityFeed, {
+              id: `status-build-${completeData.status}-${Date.now()}`,
+              kind: 'status',
+              timestamp: new Date(),
+              label: completeData.status === 'completed' ? 'Build complete' : 'Build failed',
+              detail: completeData.summary?.slice(0, 120),
+              status: completeData.status === 'completed' ? 'success' : 'error',
+            });
             break;
 
           case 'build-summary':
             const summaryData = update.data as { summary?: string };
             if (summaryData.summary) {
               newState.buildSummary = summaryData.summary;
+              newState.activityFeed = upsertActivityItem(newState.activityFeed, {
+                id: `text-summary-${Date.now()}`,
+                kind: 'text',
+                timestamp: new Date(),
+                label: summaryData.summary.slice(0, 200),
+                status: 'info',
+              });
             }
             break;
 
@@ -450,28 +554,58 @@ export function useBuildWebSocket({
               }
               // Note: We don't clear activePlanningTool on output-available anymore
               // The next input-available will replace it, keeping the UI responsive
-              break;
+            } else {
+              // Handle execution phase tools (todoIndex >= 0)
+              const targetTodoIndex = toolData.todoIndex;
+              const existingTools = newState.toolsByTodo[targetTodoIndex] || [];
+
+              // Check if tool already exists (prevent duplicates)
+              const existingIndex = existingTools.findIndex(t => t.id === toolData.id);
+              if (existingIndex >= 0) {
+                // Update in place so running -> completed is reflected live
+                const updatedTools = existingTools.map((t, idx) =>
+                  idx === existingIndex
+                    ? {
+                        ...t,
+                        ...toolCall,
+                        endTime:
+                          toolData.state === 'output-available' || toolData.state === 'error'
+                            ? new Date()
+                            : t.endTime,
+                      }
+                    : t
+                );
+                newState.toolsByTodo = {
+                  ...newState.toolsByTodo,
+                  [targetTodoIndex]: updatedTools,
+                };
+              } else {
+                // Track running and completed tools for the activity feed
+                newState.toolsByTodo = {
+                  ...newState.toolsByTodo,
+                  [targetTodoIndex]: [...existingTools, toolCall],
+                };
+              }
             }
 
-            // Handle execution phase tools (todoIndex >= 0)
-            const targetTodoIndex = toolData.todoIndex;
-            const existingTools = newState.toolsByTodo[targetTodoIndex] || [];
-
-            // Check if tool already exists (prevent duplicates)
-            const existingIndex = existingTools.findIndex(t => t.id === toolData.id);
-            if (existingIndex >= 0) {
-              break;
-            }
-
-            // Only add completed tools to toolsByTodo (for display in todo list)
-            if (toolData.state === 'output-available' || toolData.state === 'error') {
-              newState.toolsByTodo = {
-                ...newState.toolsByTodo,
-                [targetTodoIndex]: [
-                  ...existingTools,
-                  toolCall,
-                ],
-              };
+            if (toolData.name !== 'TodoWrite') {
+              const activityStatus =
+                toolData.state === 'error'
+                  ? 'error'
+                  : toolData.state === 'output-available'
+                    ? 'completed'
+                    : 'running';
+              newState.activityFeed = upsertActivityItem(newState.activityFeed, {
+                id: `tool-${toolData.id}`,
+                kind: 'tool',
+                timestamp: new Date(update.timestamp || Date.now()),
+                label: toolData.name,
+                detail: getToolResourceLabel(toolCall),
+                status: activityStatus,
+                toolName: toolData.name,
+                toolId: toolData.id,
+                todoIndex: toolData.todoIndex,
+              });
             }
             break;
         }

--- a/apps/hatchway/src/lib/sandbox/manager.ts
+++ b/apps/hatchway/src/lib/sandbox/manager.ts
@@ -179,7 +179,21 @@ export async function syncAndRun(project: SandboxProject, options: SyncAndRunOpt
     // node_modules, so extracting over it only refreshes source.
     `mkdir -p ${WORKSPACE}`,
     `find ${WORKSPACE} -mindepth 1 -maxdepth 1 ! -name node_modules -exec rm -rf {} + 2>/dev/null || true`,
-    `base64 -d /tmp/workspace.tgz.b64 | tar xz -C ${WORKSPACE}`,
+    // macOS-created tarballs may still carry unknown pax/xattr headers
+    // (LIBARCHIVE.xattr.*). GNU tar treats some as fatal; ignore them.
+    `base64 -d /tmp/workspace.tgz.b64 | tar xz --no-same-owner --warning=no-unknown-keyword -C ${WORKSPACE} 2>/tmp/tar-extract.err || { ` +
+      `ec=$?; ` +
+      // Retry without --warning if the sandbox tar is busybox/old and rejects the flag.
+      `if grep -qiE 'unrecognized|invalid option|not supported|unknown option' /tmp/tar-extract.err 2>/dev/null; then ` +
+        `base64 -d /tmp/workspace.tgz.b64 | tar xz --no-same-owner -C ${WORKSPACE}; ` +
+      `else ` +
+        // If the only "errors" are unknown extended headers, treat as success when files landed.
+        `if [ "$ec" -ne 0 ] && grep -qE "Ignoring unknown extended header|LIBARCHIVE\\.xattr" /tmp/tar-extract.err 2>/dev/null && [ -n "$(ls -A ${WORKSPACE} 2>/dev/null)" ]; then ` +
+          `echo "[sandbox] tar reported xattr warnings but extract landed files; continuing"; ` +
+        `else ` +
+          `cat /tmp/tar-extract.err >&2; exit "$ec"; ` +
+        `fi; ` +
+      `fi; }`,
     'rm -f /tmp/workspace.tgz.b64',
     `cd ${WORKSPACE}`,
     installCommand,

--- a/apps/hatchway/src/types/generation.ts
+++ b/apps/hatchway/src/types/generation.ts
@@ -3,6 +3,8 @@ export type {
   TodoItem,
   ToolCall,
   TextMessage,
+  ActivityItem,
+  ActivityItemKind,
   BuildOperationType,
   GenerationSessionStatus,
   BuildPhase,

--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -1742,6 +1742,8 @@ export async function startRunner(options: RunnerOptions = {}) {
     'tunnel-closed',
     'port-conflict',
     'process-exited',
+    'preview-failed',
+    'status',
     'error',
     'ack',
   ];
@@ -1772,6 +1774,10 @@ export async function startRunner(options: RunnerOptions = {}) {
           if (event.stack) {
             log(`Stack: ${event.stack.substring(0, 500)}`);
           }
+        } else if (event.type === "preview-failed") {
+          log(`⚠️ Preview failed: ${event.error}`);
+        } else if (event.type === "status") {
+          log(`ℹ️ ${event.message}`);
         } else if (event.type === "port-detected") {
           log(`🔌 Port detected: ${event.port}`);
         } else if (event.type === "tunnel-created") {
@@ -1920,6 +1926,12 @@ export async function startRunner(options: RunnerOptions = {}) {
           if (executionMode === 'sandbox') {
             const sandboxPort = preferredPort ?? 3000;
             log(`📦 Sandbox mode: syncing workspace to backend sandbox (project ${command.projectId}, port ${sandboxPort})...`);
+            sendEvent({
+              type: "status",
+              ...buildEventBase(command.projectId, command.id),
+              message: "Provisioning sandbox preview…",
+              phase: "sandbox-sync",
+            });
             try {
               const { syncToSandbox } = await import('./lib/sandbox-sync.js');
               const { previewUrl } = await syncToSandbox({
@@ -1937,14 +1949,23 @@ export async function startRunner(options: RunnerOptions = {}) {
                 port: sandboxPort,
                 tunnelUrl: previewUrl,
               });
+              sendEvent({
+                type: "status",
+                ...buildEventBase(command.projectId, command.id),
+                message: `Sandbox preview live`,
+                phase: "sandbox-ready",
+              });
             } catch (syncErr) {
               const message = syncErr instanceof Error ? syncErr.message : String(syncErr);
               log(`❌ Sandbox sync failed: ${message}`);
+              // Preview provision failed after a successful build. Do NOT emit a
+              // generic build "error" that the UI reads as "Build failed".
               sendEvent({
-                type: "error",
+                type: "preview-failed",
                 ...buildEventBase(command.projectId, command.id),
-                error: `Sandbox sync failed: ${message}`,
+                error: message,
                 stack: syncErr instanceof Error ? syncErr.stack : undefined,
+                phase: "sandbox-sync",
               });
             }
             break;

--- a/apps/runner/src/lib/sandbox-sync.ts
+++ b/apps/runner/src/lib/sandbox-sync.ts
@@ -22,10 +22,8 @@ export function tarWorkspaceBase64(dir: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     const errChunks: Buffer[] = [];
-    const args = [
+    const baseArgs = [
       '-czf', '-',
-      // Prefer portable archives: no macOS resource forks / xattrs when supported.
-      '--no-xattrs',
       '--exclude=node_modules',
       '--exclude=.git',
       '--exclude=.next',
@@ -37,15 +35,31 @@ export function tarWorkspaceBase64(dir: string): Promise<string> {
       '.',
     ];
 
-    const trySpawn = (tarArgs: string[], env: NodeJS.ProcessEnv) => {
-      const tar = spawn('tar', tarArgs, {
-        env: {
-          ...env,
-          // macOS: stop packing ._ resource forks / copyfile xattrs into ustar headers.
-          COPYFILE_DISABLE: '1',
-          TAR_OPTIONS: [env.TAR_OPTIONS, '--no-xattrs'].filter(Boolean).join(' ').trim() || undefined,
-        },
-      });
+    const buildEnv = (withNoXattrs: boolean): NodeJS.ProcessEnv => {
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        // macOS: stop packing ._ resource forks / copyfile xattrs into ustar headers.
+        COPYFILE_DISABLE: '1',
+      };
+      // Only inject --no-xattrs into TAR_OPTIONS when we also pass it on argv.
+      // Retry path must omit both, or older/busybox tar keeps failing the same way.
+      if (withNoXattrs) {
+        env.TAR_OPTIONS = [process.env.TAR_OPTIONS, '--no-xattrs'].filter(Boolean).join(' ').trim();
+      } else if (process.env.TAR_OPTIONS) {
+        env.TAR_OPTIONS = process.env.TAR_OPTIONS
+          .split(/\s+/)
+          .filter((part) => part && part !== '--no-xattrs')
+          .join(' ')
+          .trim() || undefined;
+      } else {
+        delete env.TAR_OPTIONS;
+      }
+      return env;
+    };
+
+    const trySpawn = (withNoXattrs: boolean) => {
+      const tarArgs = withNoXattrs ? ['--no-xattrs', ...baseArgs] : baseArgs;
+      const tar = spawn('tar', tarArgs, { env: buildEnv(withNoXattrs) });
       tar.stdout.on('data', (c: Buffer) => chunks.push(c));
       tar.stderr.on('data', (c: Buffer) => errChunks.push(c));
       tar.on('error', reject);
@@ -56,17 +70,17 @@ export function tarWorkspaceBase64(dir: string): Promise<string> {
         }
         const errText = Buffer.concat(errChunks).toString();
         // Older/busybox tar may not support --no-xattrs; retry without it but keep COPYFILE_DISABLE.
-        if (tarArgs.includes('--no-xattrs') && /unrecognized|invalid option|not supported|unknown option/i.test(errText)) {
+        if (withNoXattrs && /unrecognized|invalid option|not supported|unknown option/i.test(errText)) {
           chunks.length = 0;
           errChunks.length = 0;
-          trySpawn(tarArgs.filter((a) => a !== '--no-xattrs'), env);
+          trySpawn(false);
           return;
         }
         reject(new Error(`tar exited ${code}: ${errText.slice(0, 300)}`));
       });
     };
 
-    trySpawn(args, process.env);
+    trySpawn(true);
   });
 }
 

--- a/apps/runner/src/lib/sandbox-sync.ts
+++ b/apps/runner/src/lib/sandbox-sync.ts
@@ -11,28 +11,62 @@ import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-/** gzip the workspace (excluding heavy/derived dirs) and base64-encode it. */
+/**
+ * gzip the workspace (excluding heavy/derived dirs) and base64-encode it.
+ *
+ * macOS tar embeds Apple xattrs (LIBARCHIVE.xattr.com.apple.provenance, etc.)
+ * that make Linux tar in the sandbox exit non-zero on extract. Disable copyfile
+ * xattrs and omit extended attributes when the local tar supports it.
+ */
 export function tarWorkspaceBase64(dir: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     const errChunks: Buffer[] = [];
-    const tar = spawn('tar', [
+    const args = [
       '-czf', '-',
+      // Prefer portable archives: no macOS resource forks / xattrs when supported.
+      '--no-xattrs',
       '--exclude=node_modules',
       '--exclude=.git',
       '--exclude=.next',
       '--exclude=dist',
       '--exclude=.turbo',
+      '--exclude=.DS_Store',
+      '--exclude=**/.DS_Store',
       '-C', dir,
       '.',
-    ]);
-    tar.stdout.on('data', (c: Buffer) => chunks.push(c));
-    tar.stderr.on('data', (c: Buffer) => errChunks.push(c));
-    tar.on('error', reject);
-    tar.on('close', (code) => {
-      if (code === 0) resolve(Buffer.concat(chunks).toString('base64'));
-      else reject(new Error(`tar exited ${code}: ${Buffer.concat(errChunks).toString().slice(0, 300)}`));
-    });
+    ];
+
+    const trySpawn = (tarArgs: string[], env: NodeJS.ProcessEnv) => {
+      const tar = spawn('tar', tarArgs, {
+        env: {
+          ...env,
+          // macOS: stop packing ._ resource forks / copyfile xattrs into ustar headers.
+          COPYFILE_DISABLE: '1',
+          TAR_OPTIONS: [env.TAR_OPTIONS, '--no-xattrs'].filter(Boolean).join(' ').trim() || undefined,
+        },
+      });
+      tar.stdout.on('data', (c: Buffer) => chunks.push(c));
+      tar.stderr.on('data', (c: Buffer) => errChunks.push(c));
+      tar.on('error', reject);
+      tar.on('close', (code) => {
+        if (code === 0) {
+          resolve(Buffer.concat(chunks).toString('base64'));
+          return;
+        }
+        const errText = Buffer.concat(errChunks).toString();
+        // Older/busybox tar may not support --no-xattrs; retry without it but keep COPYFILE_DISABLE.
+        if (tarArgs.includes('--no-xattrs') && /unrecognized|invalid option|not supported|unknown option/i.test(errText)) {
+          chunks.length = 0;
+          errChunks.length = 0;
+          trySpawn(tarArgs.filter((a) => a !== '--no-xattrs'), env);
+          return;
+        }
+        reject(new Error(`tar exited ${code}: ${errText.slice(0, 300)}`));
+      });
+    };
+
+    trySpawn(args, process.env);
   });
 }
 

--- a/packages/agent-core/src/lib/websocket/server.ts
+++ b/packages/agent-core/src/lib/websocket/server.ts
@@ -135,6 +135,8 @@ class BuildWebSocketServer {
   private clients: Map<string, ClientSubscription> = new Map();
   private runnerConnections: Map<string, RunnerConnection> = new Map();
   private pendingUpdates: Map<string, BatchedUpdate> = new Map();
+  /** Recent activity-status updates retained briefly when no client is subscribed. */
+  private activityStatusBuffer: Map<string, BatchedUpdate['updates']> = new Map();
   private batchInterval: NodeJS.Timeout | null = null;
   private heartbeatInterval: NodeJS.Timeout | null = null;
   private runnerCleanupInterval: NodeJS.Timeout | null = null;
@@ -144,6 +146,8 @@ class BuildWebSocketServer {
   private readonly CLIENT_TIMEOUT = 60000; // 60s
   private readonly RUNNER_PING_INTERVAL = 30000; // 30s
   private readonly RUNNER_HEARTBEAT_TIMEOUT = 90000; // 90s
+  private readonly ACTIVITY_BUFFER_TTL_MS = 10 * 60 * 1000; // 10 minutes
+  private readonly ACTIVITY_BUFFER_MAX = 50;
 
   // Metrics tracking for runner connections
   private runnerTotalEvents = 0;
@@ -1226,6 +1230,55 @@ class BuildWebSocketServer {
   }
 
   /**
+   * Retain activity-status updates briefly so reconnecting clients still see
+   * preview/status failures that landed while they were offline.
+   */
+  private bufferActivityUpdates(projectId: string, updates: BatchedUpdate['updates']) {
+    const activityUpdates = updates.filter((u) => u.type === 'activity-status');
+    if (activityUpdates.length === 0) return;
+
+    const now = Date.now();
+    const existing = (this.activityStatusBuffer.get(projectId) || []).filter(
+      (u) => now - (u.timestamp || 0) < this.ACTIVITY_BUFFER_TTL_MS
+    );
+    const merged = [...existing, ...activityUpdates];
+    this.activityStatusBuffer.set(
+      projectId,
+      merged.length > this.ACTIVITY_BUFFER_MAX
+        ? merged.slice(merged.length - this.ACTIVITY_BUFFER_MAX)
+        : merged
+    );
+  }
+
+  private getBufferedActivityUpdates(projectId: string): BatchedUpdate['updates'] {
+    const now = Date.now();
+    const buffered = (this.activityStatusBuffer.get(projectId) || []).filter(
+      (u) => now - (u.timestamp || 0) < this.ACTIVITY_BUFFER_TTL_MS
+    );
+    // Keep entries for other reconnecting clients until TTL expires.
+    if (buffered.length === 0) {
+      this.activityStatusBuffer.delete(projectId);
+    } else {
+      this.activityStatusBuffer.set(projectId, buffered);
+    }
+    return buffered;
+  }
+
+  private latestPreviewErrorFromActivity(
+    updates: BatchedUpdate['updates']
+  ): string | undefined {
+    for (let i = updates.length - 1; i >= 0; i--) {
+      const update = updates[i];
+      if (update.type !== 'activity-status') continue;
+      const data = update.data as { message?: string; level?: string } | undefined;
+      if (data?.level === 'error' && typeof data.message === 'string' && /preview failed/i.test(data.message)) {
+        return data.message;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Flush a specific batch to clients
    */
   private flushBatch(key: string) {
@@ -1233,6 +1286,9 @@ class BuildWebSocketServer {
     if (!batch || batch.updates.length === 0) return;
 
     const { projectId, sessionId, updates } = batch;
+
+    // Always buffer activity-status (incl. preview-failed) so reconnects can recover it.
+    this.bufferActivityUpdates(projectId, updates);
 
     // Find all clients subscribed to this project/session.
     // Empty sessionId = project-wide broadcast (status / preview-failed).
@@ -1242,7 +1298,7 @@ class BuildWebSocketServer {
     );
 
     if (subscribers.length === 0) {
-      // No subscribers, clear batch
+      // No live subscribers; activity already buffered above.
       this.pendingUpdates.delete(key);
       return;
     }
@@ -1285,6 +1341,91 @@ class BuildWebSocketServer {
   }
 
   /**
+   * Enrich recovered generation state with buffered activity + project preview errors
+   * so clients that missed live broadcasts still see the correct status.
+   */
+  private async enrichRecoveredState(
+    projectId: string,
+    state: Record<string, unknown> | null | undefined
+  ): Promise<Record<string, unknown> | null> {
+    if (!state) return null;
+
+    const next: Record<string, unknown> = { ...state };
+    const buffered = this.getBufferedActivityUpdates(projectId);
+
+    if (buffered.length > 0) {
+      const existingFeed = Array.isArray(next.activityFeed)
+        ? ([...next.activityFeed] as Array<Record<string, unknown>>)
+        : [];
+      for (const update of buffered) {
+        const data = (update.data || {}) as {
+          message?: string;
+          phase?: string;
+          level?: string;
+        };
+        const id = `status-${data.phase || 'general'}-${update.timestamp || Date.now()}`;
+        if (existingFeed.some((item) => item.id === id)) continue;
+        existingFeed.push({
+          id,
+          kind: 'status',
+          timestamp: new Date(update.timestamp || Date.now()),
+          label: data.message || 'Status update',
+          detail: data.phase,
+          status: data.level || 'info',
+        });
+      }
+      next.activityFeed = existingFeed;
+
+      const bufferedPreviewError = this.latestPreviewErrorFromActivity(buffered);
+      if (bufferedPreviewError && !next.previewError) {
+        next.previewError = bufferedPreviewError;
+      }
+    }
+
+    if (!next.previewError) {
+      try {
+        const [project] = await db
+          .select({
+            errorMessage: projects.errorMessage,
+            devServerStatus: projects.devServerStatus,
+            status: projects.status,
+          })
+          .from(projects)
+          .where(eq(projects.id, projectId))
+          .limit(1);
+
+        if (
+          project?.errorMessage &&
+          project.devServerStatus === 'failed' &&
+          project.status !== 'failed' &&
+          /preview failed|sandbox sync failed/i.test(project.errorMessage)
+        ) {
+          next.previewError = project.errorMessage;
+          const feed = Array.isArray(next.activityFeed)
+            ? ([...next.activityFeed] as Array<Record<string, unknown>>)
+            : [];
+          if (!feed.some((item) => item.id === 'status-preview-error-recovered')) {
+            feed.push({
+              id: 'status-preview-error-recovered',
+              kind: 'status',
+              timestamp: new Date(),
+              label: project.errorMessage,
+              status: 'error',
+            });
+            next.activityFeed = feed;
+          }
+        }
+      } catch (error) {
+        buildLogger.websocket.error('Failed to load project preview error for recovery', error, {
+          projectId,
+        });
+      }
+    }
+
+    return next;
+  }
+
+  /**
    * Send current state to a client (on reconnect)
    * Fetches the active build session from database and sends full state
    */
@@ -1323,19 +1464,37 @@ class BuildWebSocketServer {
 
         if (recentSessions.length > 0 && recentSessions[0].rawState) {
           buildLogger.log('debug', 'websocket', `Sending completed session state for project ${client.projectId}`);
+          const enriched = await this.enrichRecoveredState(
+            client.projectId,
+            recentSessions[0].rawState as Record<string, unknown>
+          );
           this.sendMessage(client.ws, {
             type: 'state-recovery',
-            state: recentSessions[0].rawState,
+            state: enriched,
             sessionStatus: recentSessions[0].status,
             timestamp: Date.now(),
           });
           return;
         }
 
-        // No session at all
+        // No session at all — still surface buffered preview/status if present
+        const emptyEnriched = await this.enrichRecoveredState(client.projectId, {
+          id: `recovery-${client.projectId}`,
+          projectId: client.projectId,
+          projectName: '',
+          todos: [],
+          toolsByTodo: {},
+          textByTodo: {},
+          activeTodoIndex: -1,
+          isActive: false,
+          startTime: new Date(),
+          activityFeed: [],
+        });
         this.sendMessage(client.ws, {
           type: 'state-recovery',
-          state: null,
+          state: emptyEnriched?.previewError || (emptyEnriched?.activityFeed as unknown[] | undefined)?.length
+            ? emptyEnriched
+            : null,
           timestamp: Date.now(),
         });
         return;
@@ -1346,9 +1505,13 @@ class BuildWebSocketServer {
       // If rawState exists, send it directly (most efficient)
       if (session.rawState) {
         buildLogger.log('debug', 'websocket', `Sending active session state for project ${client.projectId}`);
+        const enriched = await this.enrichRecoveredState(
+          client.projectId,
+          session.rawState as Record<string, unknown>
+        );
         this.sendMessage(client.ws, {
           type: 'state-recovery',
-          state: session.rawState,
+          state: enriched,
           sessionId: session.id,
           sessionStatus: session.status,
           timestamp: Date.now(),
@@ -1412,12 +1575,18 @@ class BuildWebSocketServer {
         buildSummary: session.summary,
         isAutoFix: session.isAutoFix,
         autoFixError: session.autoFixError,
+        activityFeed: [],
       };
+
+      const enriched = await this.enrichRecoveredState(
+        client.projectId,
+        reconstructedState as unknown as Record<string, unknown>
+      );
 
       buildLogger.log('debug', 'websocket', `Sending reconstructed state for project ${client.projectId}`);
       this.sendMessage(client.ws, {
         type: 'state-recovery',
-        state: reconstructedState,
+        state: enriched,
         sessionId: session.id,
         sessionStatus: session.status,
         timestamp: Date.now(),

--- a/packages/agent-core/src/lib/websocket/server.ts
+++ b/packages/agent-core/src/lib/websocket/server.ts
@@ -1188,6 +1188,35 @@ class BuildWebSocketServer {
   }
 
   /**
+   * Broadcast a non-todo activity status line (sandbox provision, preview failure, etc.)
+   * When sessionId is empty, deliver to all clients subscribed to the project.
+   */
+  broadcastActivityStatus(
+    projectId: string,
+    sessionId: string,
+    payload: { message: string; phase?: string; level?: 'info' | 'success' | 'warning' | 'error' }
+  ) {
+    const key = sessionId ? `${projectId}-${sessionId}` : `${projectId}-activity`;
+
+    if (!this.pendingUpdates.has(key)) {
+      this.pendingUpdates.set(key, {
+        projectId,
+        sessionId: sessionId || '',
+        updates: [],
+      });
+    }
+
+    const batch = this.pendingUpdates.get(key)!;
+    batch.updates.push({
+      type: 'activity-status',
+      data: payload,
+      timestamp: Date.now(),
+    });
+
+    this.flushBatch(key);
+  }
+
+  /**
    * Process and send batched updates
    */
   private processBatchedUpdates() {
@@ -1205,10 +1234,11 @@ class BuildWebSocketServer {
 
     const { projectId, sessionId, updates } = batch;
 
-    // Find all clients subscribed to this project/session
+    // Find all clients subscribed to this project/session.
+    // Empty sessionId = project-wide broadcast (status / preview-failed).
     const subscribers = Array.from(this.clients.values()).filter(
       client => client.projectId === projectId &&
-                (!client.sessionId || client.sessionId === sessionId)
+                (!sessionId || !client.sessionId || client.sessionId === sessionId)
     );
 
     if (subscribers.length === 0) {

--- a/packages/agent-core/src/shared/runner/messages.ts
+++ b/packages/agent-core/src/shared/runner/messages.ts
@@ -56,6 +56,8 @@ export type RunnerEventType =
   | 'hmr-message'
   | 'hmr-disconnected'
   | 'hmr-error'
+  | 'status'
+  | 'preview-failed'
   | 'error';
 
 export interface BaseCommand {
@@ -468,6 +470,24 @@ export interface ErrorEvent extends BaseEvent {
   stack?: string;
 }
 
+/** Non-fatal progress note (e.g. sandbox provisioning). */
+export interface StatusEvent extends BaseEvent {
+  type: 'status';
+  message: string;
+  phase?: string;
+}
+
+/**
+ * Preview/sandbox provision failed after a successful build.
+ * Must NOT mark the generation session as failed.
+ */
+export interface PreviewFailedEvent extends BaseEvent {
+  type: 'preview-failed';
+  error: string;
+  stack?: string;
+  phase?: string;
+}
+
 export interface DevServerErrorEvent extends BaseEvent {
   type: 'dev-server-error';
   error: string;
@@ -562,6 +582,8 @@ export type RunnerEvent =
   | HmrMessageEvent
   | HmrDisconnectedEvent
   | HmrErrorEvent
+  | StatusEvent
+  | PreviewFailedEvent
   | ErrorEvent;
 
 export type RunnerMessage = RunnerCommand | RunnerEvent;

--- a/packages/agent-core/src/types/generation.ts
+++ b/packages/agent-core/src/types/generation.ts
@@ -25,6 +25,23 @@ export interface TextMessage {
   timestamp: Date;
 }
 
+/** Chronological activity line for the TUI-like build feed. */
+export type ActivityItemKind = 'tool' | 'text' | 'status' | 'todo';
+
+export interface ActivityItem {
+  id: string;
+  kind: ActivityItemKind;
+  timestamp: Date;
+  /** Short primary label (tool name, status message, note preview). */
+  label: string;
+  /** Secondary detail (file path, command, phase). */
+  detail?: string;
+  status?: 'running' | 'completed' | 'error' | 'info' | 'warning' | 'success';
+  toolName?: string;
+  toolId?: string;
+  todoIndex?: number;
+}
+
 export type BuildOperationType =
   | 'initial-build'
   | 'enhancement'
@@ -127,6 +144,9 @@ export interface GenerationState {
   currentPhase?: BuildPhase; // Current active phase
   templateTodos?: TodoItem[]; // Phase 1: Template configuration tasks
   activeTemplateTodoIndex?: number; // Active todo index for template phase
+  // TUI-like chronological activity feed (tools, notes, status)
+  activityFeed?: ActivityItem[];
+  previewError?: string; // Sandbox/preview provision error (build itself may have succeeded)
 }
 
 export type GenerationEvent =


### PR DESCRIPTION
## Summary
- Harden macOS→Linux sandbox tarball pack/extract so Apple xattrs no longer 502 preview provision after a successful build.
- Emit `status` / `preview-failed` runner events and treat sandbox sync failure as preview-only (not build failure).
- Replace the fragile TodoWrite checklist UI with a scrolling TUI-like activity feed of tools, status, and notes; broadcast execution tool starts immediately.

## Test plan
- [ ] Rerun a sandbox-mode build from macOS (e.g. Linear clone) and confirm preview provisions without tar xattr 502.
- [ ] Confirm a successful build + failed preview shows "Preview failed" (not "Build failed" / generation failed).
- [ ] Confirm left panel streams live tool activity during build even when agent skips TodoWrite.
- [ ] Confirm "Show tasks" still exposes the legacy todo list when todos exist.