### PR TITLE
fix: activity feed + sandbox install failures

### DIFF
--- a/apps/hatchway/src/app/api/build-events/route.ts
+++ b/apps/hatchway/src/app/api/build-events/route.ts
@@ -220,8 +220,8 @@ function formatToolLogMessage(toolName: string, input: unknown): string {
     }
     
     case 'TodoWrite': {
-      const todos = args.todos;
-      if (Array.isArray(todos)) {
+      const todos = normalizeTodoWriteTodos(args.todos);
+      if (todos.length > 0) {
         return `Update tasks (${todos.length} items)`;
       }
       return 'Update tasks';
@@ -230,6 +230,55 @@ function formatToolLogMessage(toolName: string, input: unknown): string {
     default:
       return toolName;
   }
+}
+
+type NormalizedTodo = {
+  content: string;
+  status: string;
+  activeForm?: string;
+};
+
+function asTodoRecord(item: unknown): NormalizedTodo | null {
+  if (!item || typeof item !== 'object') return null;
+  const rec = item as Record<string, unknown>;
+  const content =
+    typeof rec.content === 'string'
+      ? rec.content
+      : typeof rec.activeForm === 'string'
+        ? rec.activeForm
+        : typeof rec.title === 'string'
+          ? rec.title
+          : '';
+  if (!content.trim()) return null;
+  return {
+    content: content.trim(),
+    status: typeof rec.status === 'string' ? rec.status : 'pending',
+    activeForm: typeof rec.activeForm === 'string' ? rec.activeForm : undefined,
+  };
+}
+
+/** Claude sometimes serializes TodoWrite.todos as a JSON string instead of an array. */
+function normalizeTodoWriteTodos(raw: unknown): NormalizedTodo[] {
+  const fromArray = (items: unknown[]): NormalizedTodo[] =>
+    items.map(asTodoRecord).filter((item): item is NormalizedTodo => item !== null);
+
+  if (Array.isArray(raw)) {
+    return fromArray(raw);
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (Array.isArray(parsed)) return fromArray(parsed);
+      if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { todos?: unknown }).todos)) {
+        return fromArray((parsed as { todos: unknown[] }).todos);
+      }
+    } catch {
+      return [];
+    }
+  }
+  return [];
 }
 
 async function ensureAuthorized(request: Request): Promise<boolean> {
@@ -404,16 +453,17 @@ export async function POST(request: Request) {
           });
 
           // DB: Upsert todos
-          const todos = Array.isArray(event.input?.todos) ? event.input.todos : [];
+          // Claude sometimes serializes `todos` as a JSON string instead of an array.
+          const todos = normalizeTodoWriteTodos(event.input?.todos);
           const prevCount = previousTodoCounts.get(sessionId) ?? 0;
 
           if (todos.length > 0) {
             const todoValues = todos.map((todo, index) => ({
               sessionId,
               todoIndex: index,
-              content: todo?.content ?? todo?.activeForm ?? 'Untitled task',
-              activeForm: todo?.activeForm ?? null,
-              status: todo?.status ?? 'pending',
+              content: todo.content,
+              activeForm: todo.activeForm ?? null,
+              status: todo.status,
               createdAt: timestamp,
               updatedAt: timestamp,
             }));
@@ -456,8 +506,8 @@ export async function POST(request: Request) {
             projectId,
             sessionId,
             todos.map(t => ({
-              content: t.content ?? t.activeForm ?? 'Untitled task',
-              status: t.status ?? 'pending',
+              content: t.content,
+              status: t.status,
               activeForm: t.activeForm,
             })),
             activeIndex,

--- a/apps/hatchway/src/app/api/runner/events/route.ts
+++ b/apps/hatchway/src/app/api/runner/events/route.ts
@@ -586,28 +586,29 @@ IMPORTANT:
               console.log(`[events] 📝 Saving build summary for project ${projectId}: ${buildSummary.slice(0, 100)}...`);
             }
 
-            // Save summary to the most recent generation session for this project
-            if (buildSummary) {
-              try {
-                // Find the most recent active/completed session for this project
-                const [latestSession] = await db.select()
-                  .from(generationSessions)
-                  .where(eq(generationSessions.projectId, projectId))
-                  .orderBy(desc(generationSessions.createdAt))
-                  .limit(1);
-                
-                if (latestSession) {
-                  await db.update(generationSessions)
-                    .set({ 
-                      summary: buildSummary,
-                      updatedAt: new Date(),
-                    })
-                    .where(eq(generationSessions.id, latestSession.id));
-                  console.log(`[events] ✅ Saved summary to session ${latestSession.id}`);
-                }
-              } catch (err) {
-                console.error(`[events] ❌ Failed to save build summary:`, err);
+            // Always mark the latest generation session completed on build-completed.
+            // Summary may arrive later via build-summary; don't leave the session
+            // active (or let a later preview error look like a build failure).
+            try {
+              const [latestSession] = await db.select()
+                .from(generationSessions)
+                .where(eq(generationSessions.projectId, projectId))
+                .orderBy(desc(generationSessions.createdAt))
+                .limit(1);
+
+              if (latestSession && latestSession.status !== 'cancelled') {
+                await db.update(generationSessions)
+                  .set({
+                    status: 'completed',
+                    ...(buildSummary ? { summary: buildSummary } : {}),
+                    endedAt: latestSession.endedAt ?? new Date(),
+                    updatedAt: new Date(),
+                  })
+                  .where(eq(generationSessions.id, latestSession.id));
+                console.log(`[events] ✅ Marked session ${latestSession.id} completed${buildSummary ? ' with summary' : ''}`);
               }
+            } catch (err) {
+              console.error(`[events] ❌ Failed to finalize generation session:`, err);
             }
 
             const [updated] = await db.update(projects)
@@ -773,7 +774,9 @@ IMPORTANT:
             try {
               await db.update(generationSessions)
                 .set({
+                  status: 'completed',
                   summary: buildSummary,
+                  endedAt: new Date(),
                   updatedAt: new Date(),
                 })
                 .where(eq(generationSessions.id, targetSessionId));

--- a/apps/hatchway/src/app/page.tsx
+++ b/apps/hatchway/src/app/page.tsx
@@ -17,10 +17,13 @@ import { useTheme } from "@/contexts/ThemeContext";
 import RenameProjectModal from "@/components/RenameProjectModal";
 import DeleteProjectModal from "@/components/DeleteProjectModal";
 import { TodoList } from "@/components/BuildProgress/TodoList";
+import { ActivityFeed } from "@/components/BuildProgress/ActivityFeed";
+import BuildProgress from "@/components/BuildProgress";
 import { CompletedTodosSummary } from "@/components/CompletedTodosSummary";
 import { ErrorDetectedSection } from "@/components/ErrorDetectedSection";
 import { PlanningPhase } from "@/components/BuildProgress/PlanningPhase";
 import { AgentNotesSection, ActiveAgentNote } from "@/components/AgentNotesSection";
+import type { ActivityItem } from "@/types/generation";
 import ProjectMetadataCard from "@/components/ProjectMetadataCard";
 import ImageAttachment from "@/components/ImageAttachment";
 import { AppSidebar } from "@/components/app-sidebar";
@@ -266,7 +269,9 @@ function HomeContent() {
 
   const isThinking =
     generationState?.isActive &&
-    (!generationState.todos || generationState.todos.length === 0);
+    (!generationState.todos || generationState.todos.length === 0) &&
+    !(generationState.activityFeed && generationState.activityFeed.length > 0) &&
+    !(generationState.planningTools && generationState.planningTools.length > 0);
   const classifyMessage = useCallback((message: Message) => {
     const role = (message.role ?? message.type ?? '').toLowerCase();
     if (role === 'user') return 'user';
@@ -1813,13 +1818,6 @@ function HomeContent() {
                 const baseState = ensureGenerationState(prev);
                 if (!baseState) return prev;
 
-                // Skip nesting if todos haven't been created yet
-                // Tools will be saved to DB and re-associated when state refreshes from backend
-                if (!baseState.todos || baseState.todos.length === 0) {
-                  // Silent: This is expected during project exploration phase
-                  return prev;
-                }
-
                 const tool: ToolCall = {
                   id: data.toolCallId,
                   name: data.toolName,
@@ -1828,11 +1826,53 @@ function HomeContent() {
                   startTime: new Date(),
                 };
 
+                const resource =
+                  typeof (data.input as { file_path?: string } | undefined)?.file_path === 'string'
+                    ? (data.input as { file_path: string }).file_path
+                    : typeof (data.input as { command?: string } | undefined)?.command === 'string'
+                      ? (data.input as { command: string }).command.slice(0, 80)
+                      : undefined;
+
+                const activityItem: ActivityItem = {
+                  id: `tool-${tool.id}`,
+                  kind: 'tool',
+                  timestamp: new Date(),
+                  label: tool.name,
+                  detail: resource,
+                  status: 'running',
+                  toolName: tool.name,
+                  toolId: tool.id,
+                };
+
+                // Before TodoWrite: keep tools on planningTools + activity feed
+                if (!baseState.todos || baseState.todos.length === 0) {
+                  const planningTools = [...(baseState.planningTools || [])];
+                  const existingIdx = planningTools.findIndex((t) => t.id === tool.id);
+                  if (existingIdx >= 0) planningTools[existingIdx] = tool;
+                  else planningTools.push(tool);
+
+                  const feed = [...(baseState.activityFeed || [])];
+                  const feedIdx = feed.findIndex((item) => item.id === activityItem.id);
+                  if (feedIdx >= 0) feed[feedIdx] = { ...feed[feedIdx], ...activityItem };
+                  else feed.push(activityItem);
+
+                  return {
+                    ...baseState,
+                    planningTools,
+                    activePlanningTool: tool,
+                    activityFeed: feed.slice(-200),
+                  };
+                }
+
                 const activeIndex =
                   baseState.activeTodoIndex >= 0
                     ? baseState.activeTodoIndex
                     : 0;
                 const existing = baseState.toolsByTodo[activeIndex] || [];
+                const feed = [...(baseState.activityFeed || [])];
+                const feedIdx = feed.findIndex((item) => item.id === activityItem.id);
+                if (feedIdx >= 0) feed[feedIdx] = { ...feed[feedIdx], ...activityItem, todoIndex: activeIndex };
+                else feed.push({ ...activityItem, todoIndex: activeIndex });
 
                 if (DEBUG_PAGE) console.log(
                   "   ✅ Nesting under todo",
@@ -1845,8 +1885,9 @@ function HomeContent() {
                   ...baseState,
                   toolsByTodo: {
                     ...baseState.toolsByTodo,
-                    [activeIndex]: [...existing, tool],
+                    [activeIndex]: [...existing.filter((t) => t.id !== tool.id), tool],
                   },
+                  activityFeed: feed.slice(-200),
                 };
 
                 if (DEBUG_PAGE) console.log(
@@ -3220,65 +3261,14 @@ function HomeContent() {
                                           </div>
                                         )}
 
-                                        {/* Active Build Progress - Skip for auto-fix sessions which are rendered separately */}
-                                        {hasActiveBuild && generationState.todos && generationState.todos.length > 0 && !generationState.isAutoFix && (
+                                        {/* Active Build Progress - activity feed (tools/status), not TodoWrite-gated */}
+                                        {hasActiveBuild && !generationState.isAutoFix && (
                                           <div className="space-y-3">
-                                            <div className="flex items-center justify-between">
-                                              <p className="text-xs uppercase tracking-[0.3em] text-gray-500">
-                                                Build in progress
-                                              </p>
-                                              <div className="flex items-center gap-2">
-                                                <div className="text-xs text-gray-400">
-                                                  {generationState.todos.filter(t => t.status === 'completed').length} / {generationState.todos.length}
-                                                </div>
-                                                <div className="text-sm font-semibold text-theme-primary">
-                                                  {Math.round((generationState.todos.filter(t => t.status === 'completed').length / generationState.todos.length) * 100)}%
-                                                </div>
-                                              </div>
-                                            </div>
-                                            <div className="h-1 overflow-hidden rounded-full bg-white/10">
-                                              <motion.div
-                                                initial={{ width: 0 }}
-                                                animate={{
-                                                  width: `${(generationState.todos.filter(t => t.status === 'completed').length / generationState.todos.length) * 100}%`,
-                                                }}
-                                                transition={{ duration: 0.5, ease: 'easeOut' }}
-                                                className="h-full bg-gradient-to-r from-emerald-400 to-sky-400"
-                                              />
-                                            </div>
-                                            <TodoList
-                                              todos={generationState.todos}
-                                              toolsByTodo={generationState.toolsByTodo}
-                                              activeTodoIndex={generationState.activeTodoIndex}
-                                              allTodosCompleted={generationState.todos.every(t => t.status === 'completed')}
+                                            <BuildProgress
+                                              state={generationState}
+                                              onCancel={cancelBuild}
+                                              isCancelling={isCancelling}
                                             />
-                                            
-                                            {/* Active agent note - shows most recent reasoning */}
-                                            {generationState.textByTodo && Object.keys(generationState.textByTodo).length > 0 && (
-                                              <ActiveAgentNote
-                                                textByTodo={generationState.textByTodo}
-                                                activeTodoIndex={generationState.activeTodoIndex}
-                                              />
-                                            )}
-
-                                            {/* Stop Build button - below the task list */}
-                                            <button
-                                              onClick={cancelBuild}
-                                              disabled={isCancelling}
-                                              className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm text-gray-400 hover:text-red-400 transition-colors rounded-lg border border-white/10 hover:border-red-500/30 hover:bg-red-500/5 disabled:opacity-50 disabled:cursor-not-allowed"
-                                            >
-                                              {isCancelling ? (
-                                                <>
-                                                  <Loader2 className="w-4 h-4 animate-spin" />
-                                                  <span>Cancelling...</span>
-                                                </>
-                                              ) : (
-                                                <>
-                                                  <Square className="w-4 h-4" />
-                                                  <span>Stop Build</span>
-                                                </>
-                                              )}
-                                            </button>
                                           </div>
                                         )}
 
@@ -3322,6 +3312,38 @@ function HomeContent() {
                                                 <CompletedTodosSummary todos={correspondingBuild.todos} />
                                               </div>
                                             )}
+
+                                            {/* Activity feed fallback for completed builds (no todos) */}
+                                            {(!correspondingBuild.todos || correspondingBuild.todos.length === 0) &&
+                                              ((correspondingBuild.activityFeed && correspondingBuild.activityFeed.length > 0) ||
+                                                (correspondingBuild.planningTools && correspondingBuild.planningTools.length > 0)) && (
+                                              <div className="space-y-2 rounded-xl theme-card overflow-hidden">
+                                                <p className="px-4 pt-3 text-xs uppercase tracking-[0.3em] text-gray-500">
+                                                  Activity
+                                                </p>
+                                                <ActivityFeed
+                                                  items={
+                                                    correspondingBuild.activityFeed && correspondingBuild.activityFeed.length > 0
+                                                      ? correspondingBuild.activityFeed
+                                                      : (correspondingBuild.planningTools || []).map((tool) => ({
+                                                          id: `tool-${tool.id}`,
+                                                          kind: 'tool' as const,
+                                                          timestamp: tool.startTime || correspondingBuild.startTime,
+                                                          label: tool.name,
+                                                          status:
+                                                            tool.state === 'error'
+                                                              ? ('error' as const)
+                                                              : tool.state === 'output-available'
+                                                                ? ('completed' as const)
+                                                                : ('running' as const),
+                                                          toolName: tool.name,
+                                                          toolId: tool.id,
+                                                        }))
+                                                  }
+                                                  isActive={false}
+                                                />
+                                              </div>
+                                            )}
                                             
                                             {/* Build summary section - show even without todos */}
                                             {correspondingBuild.buildSummary && (
@@ -3334,6 +3356,12 @@ function HomeContent() {
                                                     {correspondingBuild.buildSummary}
                                                   </ReactMarkdown>
                                                 </div>
+                                              </div>
+                                            )}
+
+                                            {correspondingBuild.previewError && (
+                                              <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200">
+                                                {correspondingBuild.previewError}
                                               </div>
                                             )}
                                           </>

--- a/apps/hatchway/src/lib/sandbox/manager.ts
+++ b/apps/hatchway/src/lib/sandbox/manager.ts
@@ -79,7 +79,11 @@ function shQuote(s: string): string {
 async function execOk(sb: Sandbox, cmd: string, timeoutSec: number): Promise<string> {
   const r = await sb.exec(cmd, { timeoutSec });
   if (r.exitCode !== 0) {
-    throw new Error(`sandbox exec failed (exit ${r.exitCode}): ${(r.stderr || r.stdout || '').slice(0, 400)}`);
+    // Prefer the tail of stderr/stdout — npm prints long warning headers first and
+    // the actual failure reason (ERESOLVE, missing binary, next bind error) last.
+    const combined = `${r.stderr || ''}\n${r.stdout || ''}`.trim();
+    const tail = combined.length > 600 ? combined.slice(-600) : combined;
+    throw new Error(`sandbox exec failed (exit ${r.exitCode}): ${tail || 'no output'}`);
   }
   return r.stdout ?? '';
 }
@@ -196,7 +200,18 @@ export async function syncAndRun(project: SandboxProject, options: SyncAndRunOpt
       `fi; }`,
     'rm -f /tmp/workspace.tgz.b64',
     `cd ${WORKSPACE}`,
-    installCommand,
+    // Template .npmrc may contain pnpm-only keys (enable-modules-dir, shamefully-hoist).
+    // npm treats unknown project config as hard errors on newer versions, so strip those
+    // keys before install when using npm. Keep the file for pnpm/yarn installs.
+    `if echo ${shQuote(installCommand)} | grep -Eq '(^|[[:space:]])npm([[:space:]]|$)'; then ` +
+      `if [ -f .npmrc ]; then ` +
+        `grep -Ev '^(enable-modules-dir|shamefully-hoist|auto-install-peers|node-linker|public-hoist-pattern)=' .npmrc > .npmrc.hatchway 2>/dev/null || true; ` +
+        `mv .npmrc.hatchway .npmrc; ` +
+      `fi; ` +
+    `fi`,
+    // Surface install failures with a log tail rather than only npm warning noise.
+    `{ ${installCommand}; } > /tmp/sandbox-install.log 2>&1 || { echo "[sandbox] install failed: ${installCommand}"; tail -n 80 /tmp/sandbox-install.log; exit 1; }`,
+    'tail -n 20 /tmp/sandbox-install.log 2>/dev/null || true',
     // Restart only the dev server with the freshly-synced code.
     'tmux kill-session -t dev 2>/dev/null || true',
     // Vite/Astro IGNORE the PORT env var (they only honor --port), so pass the

--- a/apps/runner/src/lib/build-orchestrator.ts
+++ b/apps/runner/src/lib/build-orchestrator.ts
@@ -508,8 +508,7 @@ Select based on user's request:
 After cloning:
 1. cd ${projectName}
 2. Create .npmrc containing:
-   enable-modules-dir=true
-   shamefully-hoist=false
+   install-links=false
 3. Update package.json "name" field to "${projectName}"
 4. Implement the user's request by modifying the template files`);
     } else {

--- a/apps/runner/src/lib/native-claude-sdk.ts
+++ b/apps/runner/src/lib/native-claude-sdk.ts
@@ -367,10 +367,22 @@ export function createNativeClaudeQuery(
         // Enable SDK debug logging only when explicitly diagnosing the SDK.
         ...(process.env.DEBUG_SKILLS === '1' ? { DEBUG_CLAUDE_AGENT_SDK: '1' } : {}),
       },
-      // Coding + TodoWrite progress. Web tools only outside initial-build.
-      // Task/MCP/plan tools stay off.
-      tools: resolvedTools,
-      disallowedTools: resolvedDisallowedTools,
+      // Use the Claude Code tool preset so built-ins like TodoWrite stay enabled.
+      // An explicit string allowlist has been observed to leave TodoWrite in a
+      // "exists but is not enabled in this context" state. Deny nested/plan/web
+      // tools via disallowedTools instead.
+      tools: { type: 'preset', preset: 'claude_code' },
+      // Keep resolvedTools logged for ops; deny list is the real gate.
+      // Also deny anything not in our intended core set on initial-build by
+      // expanding disallowedTools with known extras beyond web/task/plan.
+      disallowedTools: [
+        ...resolvedDisallowedTools,
+        // Extra Claude Code tools we never want during Hatchway builds.
+        'TaskOutput',
+        'KillShell',
+        'ListMcpResources',
+        'ReadMcpResource',
+      ],
       // Pass abort controller for cancellation support
       // NOTE: There is a known bug in the Claude Agent SDK where AbortController
       // signals are not fully respected. When abort() is called, the SDK may

--- a/apps/runner/src/lib/templates/downloader.ts
+++ b/apps/runner/src/lib/templates/downloader.ts
@@ -131,9 +131,11 @@ export async function downloadTemplateWithGit(
  */
 async function createNpmrc(projectPath: string): Promise<void> {
   const npmrcPath = join(projectPath, '.npmrc');
-  const npmrcContent = `# Disable workspace mode - treat as standalone project
-enable-modules-dir=true
-shamefully-hoist=false
+  // Keep this npm-safe. pnpm-only keys (enable-modules-dir, shamefully-hoist)
+  // make newer npm fail project installs inside the sandbox with
+  // "Unknown project config" errors.
+  const npmrcContent = `# Standalone project (no monorepo workspace linking)
+install-links=false
 `;
 
   try {

--- a/packages/agent-core/src/lib/runner/persistent-event-processor.ts
+++ b/packages/agent-core/src/lib/runner/persistent-event-processor.ts
@@ -140,8 +140,23 @@ export function registerBuild(
             const toolName = eventData.toolName as string | undefined;
             
             if (toolName === 'TodoWrite') {
-              const input = eventData.input as { todos?: Array<{ content?: string; activeForm?: string; status?: string }> } | undefined;
-              const todos = Array.isArray(input?.todos) ? input.todos : [];
+              const input = eventData.input as { todos?: unknown } | undefined;
+              let todosRaw = input?.todos;
+              if (typeof todosRaw === 'string') {
+                try {
+                  const parsed = JSON.parse(todosRaw) as unknown;
+                  todosRaw = Array.isArray(parsed)
+                    ? parsed
+                    : parsed && typeof parsed === 'object' && Array.isArray((parsed as { todos?: unknown }).todos)
+                      ? (parsed as { todos: unknown[] }).todos
+                      : [];
+                } catch {
+                  todosRaw = [];
+                }
+              }
+              const todos = Array.isArray(todosRaw)
+                ? todosRaw.filter((t): t is { content?: string; activeForm?: string; status?: string } => !!t && typeof t === 'object')
+                : [];
               
               // Update local active todo index for tracking
               context.currentActiveTodoIndex = todos.findIndex(t => t.status === 'in_progress');


### PR DESCRIPTION
## Summary
- Left panel now renders live `BuildProgress` activity (tools/status) instead of only showing when TodoWrite todos exist.
- Parse TodoWrite `todos` when Claude sends them as a JSON string; use Claude Code tool preset so TodoWrite is actually enabled.
- Sandbox install: strip pnpm-only `.npmrc` keys before `npm install`, capture stderr tail for real failure reasons, and mark generation sessions completed on successful builds.

## Evidence from Linear Clone failure
- Build completed in ~4.5m / 12 files / early-stop write budget.
- Preview failed after tar fix: sandbox `npm install` choked on template `.npmrc` pnpm keys (`enable-modules-dir`, `shamefully-hoist`).
- Activity feed empty because page still gated on todos, and TodoWrite failed with "not enabled in this context" plus stringified todos.

## Test plan
- [ ] Rerun Linear clone sandbox build and confirm left panel streams tool activity live.
- [ ] Confirm TodoWrite succeeds and todos appear when agent uses them.
- [ ] Confirm sandbox preview provisions (or at least surfaces the real install/dev error tail).
- [ ] Confirm successful builds leave generation session status `completed` (not `failed`).