### PR TITLE
fix: sandbox native builds and Claude chat feed

### DIFF
--- a/apps/hatchway/scripts/bake-sandbox-checkpoint.ts
+++ b/apps/hatchway/scripts/bake-sandbox-checkpoint.ts
@@ -52,16 +52,27 @@ async function main() {
   try {
     // Railway's base image ships Node via mise. The sandbox is the RUN target,
     // so it needs: railgate (preview tunnel), tmux (keep the dev server + tunnel
-    // alive across exec sessions), and pnpm (most templates). No @hatchway/cli —
-    // the runner + Claude Code run on the user's machine.
-    await step(sb, 'Install tmux', `apt-get update -qq && apt-get install -y -qq tmux`, 600);
+    // alive across exec sessions), pnpm (most templates), and a native build
+    // toolchain for modules like better-sqlite3 that rebuild via node-gyp.
+    // No @hatchway/cli — the runner + Claude Code run on the user's machine.
+    await step(
+      sb,
+      'Install tmux + native build toolchain',
+      `apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq tmux build-essential python3 python3-pip pkg-config`,
+      600,
+    );
     await step(
       sb,
       `Install ${railgatePackage} + pnpm`,
       `npm i -g ${railgatePackage} && (corepack enable || npm i -g pnpm)`,
       600,
     );
-    await step(sb, 'Verify tools', `node --version && railgate --version && tmux -V && pnpm --version`, 60);
+    await step(
+      sb,
+      'Verify tools',
+      `node --version && railgate --version && tmux -V && pnpm --version && g++ --version | head -1 && make --version | head -1 && python3 --version`,
+      60,
+    );
 
     console.log(`\nCheckpointing as "${checkpointName}"...`);
     const cp = await sb.checkpoint(checkpointName);

--- a/apps/hatchway/src/app/page.tsx
+++ b/apps/hatchway/src/app/page.tsx
@@ -1667,6 +1667,7 @@ function HomeContent() {
             textBlocksMap.set(data.id, { type: "text", text: "" });
           } else if (data.type === "text-delta") {
             const blockId = data.id;
+            const delta = typeof data.delta === "string" ? data.delta : "";
 
             // Get or create text block
             let textBlock = textBlocksMap.get(blockId);
@@ -1676,7 +1677,60 @@ function HomeContent() {
             }
 
             // Accumulate text
-            textBlock.text += data.delta;
+            textBlock.text += delta;
+
+            // Stream Claude narrative into the live activity feed (TUI-style chat).
+            // Prefer whole deltas when the runner sends complete assistant turns;
+            // still support true token streaming by upserting the same block id.
+            if (delta.trim().length > 0 || textBlock.text.trim().length > 0) {
+              const displayText = textBlock.text.trim();
+              if (displayText.length > 0) {
+                updateGenerationState((prev) => {
+                  if (!prev) return null;
+                  const activeIndex =
+                    prev.activeTodoIndex >= 0 ? prev.activeTodoIndex : 0;
+                  const existing = prev.textByTodo[activeIndex] || [];
+                  const textMsg = {
+                    id: blockId,
+                    text: displayText,
+                    timestamp: new Date(),
+                  };
+                  const textIdx = existing.findIndex((t) => t.id === blockId);
+                  const nextTextByTodo = [...existing];
+                  if (textIdx >= 0) nextTextByTodo[textIdx] = textMsg;
+                  else nextTextByTodo.push(textMsg);
+
+                  const feed = [...(prev.activityFeed || [])];
+                  const activityItem: ActivityItem = {
+                    id: `text-${blockId}`,
+                    kind: "text",
+                    timestamp: new Date(),
+                    label: displayText.length > 400 ? `${displayText.slice(0, 400)}…` : displayText,
+                    status: "info",
+                    todoIndex: activeIndex,
+                  };
+                  const feedIdx = feed.findIndex((item) => item.id === activityItem.id);
+                  if (feedIdx >= 0) {
+                    feed[feedIdx] = {
+                      ...feed[feedIdx],
+                      ...activityItem,
+                      timestamp: feed[feedIdx].timestamp,
+                    };
+                  } else {
+                    feed.push(activityItem);
+                  }
+
+                  return {
+                    ...prev,
+                    textByTodo: {
+                      ...prev.textByTodo,
+                      [activeIndex]: nextTextByTodo,
+                    },
+                    activityFeed: feed.slice(-200),
+                  };
+                });
+              }
+            }
 
             // Update message content (simplified - just update content string!)
             if (currentMessage?.id) {
@@ -1710,8 +1764,7 @@ function HomeContent() {
             }
           } else if (data.type === "text-end") {
             if (DEBUG_PAGE) console.log("✅ Text block finished:", data.id);
-            // Text messages are stored in textByTodo and displayed inside BuildProgress
-            // Don't add to main conversation messages array
+            // Narrative text already lives in activityFeed / textByTodo from text-delta
           } else if (data.type?.startsWith("codex-")) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             updateCodexState((codex) => processCodexEvent(codex, data as any));
@@ -1983,23 +2036,33 @@ function HomeContent() {
                 const activeIndex =
                   prev.activeTodoIndex >= 0 ? prev.activeTodoIndex : 0;
                 const existing = prev.textByTodo[activeIndex] || [];
+                const textId = `reasoning-${Date.now()}`;
+                const text = String(message);
+                const feed = [...(prev.activityFeed || [])];
+                feed.push({
+                  id: `text-${textId}`,
+                  kind: 'text',
+                  timestamp: new Date(),
+                  label: text.length > 400 ? `${text.slice(0, 400)}…` : text,
+                  status: 'info',
+                  todoIndex: activeIndex,
+                });
 
-                const updated = {
+                return {
                   ...prev,
                   textByTodo: {
                     ...prev.textByTodo,
                     [activeIndex]: [
                       ...existing,
                       {
-                        id: `reasoning-${Date.now()}`,
-                        text: message,
+                        id: textId,
+                        text,
                         timestamp: new Date(),
                       },
                     ],
                   },
+                  activityFeed: feed.slice(-200),
                 };
-
-                return updated;
               });
             }
           } else if (

--- a/apps/hatchway/src/components/BuildProgress/ActivityFeed.tsx
+++ b/apps/hatchway/src/components/BuildProgress/ActivityFeed.tsx
@@ -2,13 +2,15 @@
 
 import { useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { CheckCircle2, Circle, Loader2, AlertTriangle, Info, MessageSquare } from 'lucide-react';
+import { CheckCircle2, Circle, Loader2, AlertTriangle, Info } from 'lucide-react';
 import type { ActivityItem } from '@/types/generation';
 
 interface ActivityFeedProps {
   items: ActivityItem[];
   isActive?: boolean;
   emptyLabel?: string;
+  /** Prefer chat-style Claude lines; tools stay secondary. */
+  agentLabel?: string;
 }
 
 function formatTime(ts: Date | string | number | undefined): string {
@@ -31,26 +33,17 @@ function StatusIcon({ item }: { item: ActivityItem }) {
   if (item.status === 'warning') {
     return <AlertTriangle className="h-3.5 w-3.5 text-amber-400 flex-shrink-0" />;
   }
-  if (item.kind === 'text') {
-    return <MessageSquare className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />;
-  }
   if (item.kind === 'status') {
     return <Info className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />;
   }
   return <Circle className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />;
 }
 
-function kindPrefix(item: ActivityItem): string {
-  if (item.kind === 'tool') return '›';
-  if (item.kind === 'todo') return '•';
-  if (item.kind === 'text') return '·';
-  return '·';
-}
-
 export function ActivityFeed({
   items,
   isActive = false,
   emptyLabel = 'Waiting for agent activity…',
+  agentLabel = 'Claude',
 }: ActivityFeedProps) {
   const scrollerRef = useRef<HTMLDivElement>(null);
   const stickToBottomRef = useRef(true);
@@ -70,7 +63,7 @@ export function ActivityFeed({
     const el = scrollerRef.current;
     if (!el || !stickToBottomRef.current) return;
     el.scrollTop = el.scrollHeight;
-  }, [items.length, items[items.length - 1]?.id, items[items.length - 1]?.status]);
+  }, [items.length, items[items.length - 1]?.id, items[items.length - 1]?.label, items[items.length - 1]?.status]);
 
   if (!items.length) {
     return (
@@ -84,18 +77,43 @@ export function ActivityFeed({
   return (
     <div
       ref={scrollerRef}
-      className="max-h-[360px] overflow-y-auto px-3 py-2 font-mono text-xs leading-relaxed"
+      className="max-h-[420px] overflow-y-auto px-3 py-3 space-y-1.5"
     >
       <AnimatePresence initial={false}>
         {items.map((item) => {
+          if (item.kind === 'text') {
+            return (
+              <motion.div
+                key={item.id}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="rounded-lg px-2.5 py-2 bg-theme-primary/5 border border-theme-primary/10"
+              >
+                <div className="flex items-baseline justify-between gap-2 mb-1">
+                  <span className="text-[11px] font-semibold tracking-wide text-theme-primary">
+                    {agentLabel}
+                  </span>
+                  <span className="text-[10px] text-muted-foreground/50 tabular-nums">
+                    {formatTime(item.timestamp)}
+                  </span>
+                </div>
+                <p className="text-sm leading-relaxed text-foreground/90 whitespace-pre-wrap break-words">
+                  {item.label}
+                </p>
+              </motion.div>
+            );
+          }
+
           const isError = item.status === 'error';
           const isRunning = item.status === 'running';
+          const isTool = item.kind === 'tool';
+
           return (
             <motion.div
               key={item.id}
               initial={{ opacity: 0, y: 4 }}
               animate={{ opacity: 1, y: 0 }}
-              className={`flex items-start gap-2 py-1 px-1 rounded ${
+              className={`flex items-start gap-2 py-1 px-1.5 rounded font-mono text-[11px] leading-relaxed ${
                 isError
                   ? 'bg-red-500/5 text-red-300'
                   : isRunning
@@ -103,36 +121,33 @@ export function ActivityFeed({
                     : 'text-muted-foreground'
               }`}
             >
-              <span className="text-muted-foreground/70 w-3 flex-shrink-0 pt-0.5">
-                {kindPrefix(item)}
-              </span>
               <StatusIcon item={item} />
               <div className="min-w-0 flex-1">
                 <div className="flex items-baseline gap-2 min-w-0">
                   <span
                     className={`truncate ${
-                      item.kind === 'tool'
+                      isTool
                         ? isRunning
-                          ? 'shimmer-text text-foreground'
-                          : 'text-foreground/90'
+                          ? 'shimmer-text text-foreground/80'
+                          : 'text-foreground/70'
                         : item.kind === 'todo'
-                          ? 'text-foreground font-medium'
+                          ? 'text-foreground/90 font-medium'
                           : isError
                             ? 'text-red-300'
-                            : 'text-foreground/80'
+                            : 'text-foreground/70'
                     }`}
                   >
-                    {item.label}
+                    {isTool ? `› ${item.label}` : item.label}
                   </span>
                   {item.detail && item.kind !== 'status' && (
-                    <span className="truncate text-muted-foreground/80">{item.detail}</span>
+                    <span className="truncate text-muted-foreground/70">{item.detail}</span>
                   )}
                 </div>
                 {item.kind === 'status' && item.detail && (
                   <div className="text-[10px] text-muted-foreground/70 mt-0.5">{item.detail}</div>
                 )}
               </div>
-              <span className="text-[10px] text-muted-foreground/50 flex-shrink-0 tabular-nums pt-0.5">
+              <span className="text-[10px] text-muted-foreground/40 flex-shrink-0 tabular-nums pt-0.5">
                 {formatTime(item.timestamp)}
               </span>
             </motion.div>
@@ -140,10 +155,9 @@ export function ActivityFeed({
         })}
       </AnimatePresence>
       {isActive && (
-        <div className="flex items-center gap-2 py-1.5 px-1 text-muted-foreground">
-          <span className="w-3" />
+        <div className="flex items-center gap-2 py-1.5 px-1.5 text-muted-foreground font-mono text-[11px]">
           <Loader2 className="h-3.5 w-3.5 animate-spin text-theme-primary" />
-          <span className="shimmer-text">working…</span>
+          <span className="shimmer-text">{agentLabel} is working…</span>
         </div>
       )}
     </div>

--- a/apps/hatchway/src/components/BuildProgress/index.tsx
+++ b/apps/hatchway/src/components/BuildProgress/index.tsx
@@ -76,6 +76,24 @@ function deriveActivityFeed(state: GenerationState): ActivityItem[] {
     });
   }
 
+  // Narrative text keyed by todo index (including 0 before todos exist)
+  const textEntries = Object.entries(state.textByTodo || {})
+    .flatMap(([idx, texts]) =>
+      (texts || []).map((text) => ({ index: Number(idx), text }))
+    )
+    .filter((entry) => entry.text?.text?.trim());
+
+  for (const { index, text } of textEntries) {
+    items.push({
+      id: `text-derived-${text.id}`,
+      kind: 'text',
+      timestamp: text.timestamp || state.startTime,
+      label: text.text,
+      status: 'info',
+      todoIndex: Number.isFinite(index) ? index : 0,
+    });
+  }
+
   (state.todos || []).forEach((todo, index) => {
     if (todo.status === 'pending') return;
     items.push({
@@ -376,7 +394,7 @@ export default function BuildProgress({
         <>
           <div className="flex items-center justify-between px-4 pt-2">
             <p className="text-[11px] uppercase tracking-wide text-muted-foreground/70">
-              {showTodoFallback ? 'Tasks' : 'Activity'}
+              {showTodoFallback ? 'Tasks' : 'Chat'}
             </p>
             {total > 0 && (
               <button
@@ -384,7 +402,7 @@ export default function BuildProgress({
                 onClick={() => setShowTodoFallback((v) => !v)}
                 className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
               >
-                {showTodoFallback ? 'Show activity' : 'Show tasks'}
+                {showTodoFallback ? 'Show chat' : 'Show tasks'}
               </button>
             )}
           </div>
@@ -426,6 +444,15 @@ export default function BuildProgress({
               items={activityItems}
               isActive={state.isActive}
               emptyLabel={state.isActive ? 'Starting agent…' : 'No activity recorded'}
+              agentLabel={
+                state.agentId === 'openai-codex'
+                  ? 'Codex'
+                  : state.agentId === 'opencode'
+                    ? 'OpenCode'
+                    : state.agentId === 'factory-droid'
+                      ? 'Droid'
+                      : 'Claude'
+              }
             />
           )}
 

--- a/apps/hatchway/src/lib/sandbox/manager.ts
+++ b/apps/hatchway/src/lib/sandbox/manager.ts
@@ -200,6 +200,13 @@ export async function syncAndRun(project: SandboxProject, options: SyncAndRunOpt
       `fi; }`,
     'rm -f /tmp/workspace.tgz.b64',
     `cd ${WORKSPACE}`,
+    // Native modules (better-sqlite3, sharp, etc.) need a compiler toolchain when
+    // prebuilds are missing for the sandbox Node ABI. Bake installs these once;
+    // this is a cheap no-op if already present, and covers fresh/unbaked boxes.
+    'if ! command -v g++ >/dev/null 2>&1 || ! command -v make >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then ' +
+      'echo "[sandbox] installing native build toolchain (python3/make/g++)"; ' +
+      'apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential python3 python3-pip pkg-config; ' +
+    'fi',
     // Template .npmrc may contain pnpm-only keys (enable-modules-dir, shamefully-hoist).
     // npm treats unknown project config as hard errors on newer versions, so strip those
     // keys before install when using npm. Keep the file for pnpm/yarn installs.
@@ -209,8 +216,11 @@ export async function syncAndRun(project: SandboxProject, options: SyncAndRunOpt
         `mv .npmrc.hatchway .npmrc; ` +
       `fi; ` +
     `fi`,
+    // Prefer prebuilt binaries when available; fall back to node-gyp with toolchain above.
+    'export npm_config_build_from_source=false',
+    'export npm_config_python=python3',
     // Surface install failures with a log tail rather than only npm warning noise.
-    `{ ${installCommand}; } > /tmp/sandbox-install.log 2>&1 || { echo "[sandbox] install failed: ${installCommand}"; tail -n 80 /tmp/sandbox-install.log; exit 1; }`,
+    `{ ${installCommand}; } > /tmp/sandbox-install.log 2>&1 || { echo "[sandbox] install failed: ${installCommand}"; tail -n 120 /tmp/sandbox-install.log; exit 1; }`,
     'tail -n 20 /tmp/sandbox-install.log 2>/dev/null || true',
     // Restart only the dev server with the freshly-synced code.
     'tmux kill-session -t dev 2>/dev/null || true',


### PR DESCRIPTION
## Summary
- Ensure sandbox has a native build toolchain (runtime + bake) so `better-sqlite3` / node-gyp installs succeed on Node 24
- Stream SSE `text-delta` / reasoning into the live activity feed as Claude chat lines
- Restyle ActivityFeed toward a scrolling chat transcript (tools secondary)

## Test plan
- [ ] Clone Linear-like template with better-sqlite3; confirm sandbox install + preview succeed
- [ ] During a build, left panel streams Claude narrative lines (not only tool cards)
- [ ] Optional: rebake `SANDBOX_BASE_CHECKPOINT` so toolchain is preinstalled