### PR TITLE
fix: show Claude narrative only in build chat

### DIFF
--- a/apps/hatchway/src/app/page.tsx
+++ b/apps/hatchway/src/app/page.tsx
@@ -1834,10 +1834,35 @@ function HomeContent() {
                   return prev;
                 }
 
+                let activityFeed = baseState.activityFeed || [];
+                const activeTodo = activeIndex >= 0 ? todos[activeIndex] : undefined;
+                if (activeTodo) {
+                  const label =
+                    (activeTodo.status === "in_progress"
+                      ? activeTodo.activeForm || activeTodo.content
+                      : activeTodo.content) || activeTodo.content;
+                  if (label?.trim()) {
+                    const item: ActivityItem = {
+                      id: `text-todo-sse-${activeIndex}-${label.slice(0, 48)}`,
+                      kind: "text",
+                      timestamp: new Date(),
+                      label,
+                      status: "info",
+                      todoIndex: activeIndex,
+                    };
+                    const feedIdx = activityFeed.findIndex((entry) => entry.id === item.id);
+                    activityFeed = [...activityFeed];
+                    if (feedIdx >= 0) activityFeed[feedIdx] = { ...activityFeed[feedIdx], ...item, timestamp: activityFeed[feedIdx].timestamp };
+                    else activityFeed.push(item);
+                    activityFeed = activityFeed.slice(-200);
+                  }
+                }
+
                 const updated = {
                   ...baseState,
                   todos,
                   activeTodoIndex: activeIndex,
+                  activityFeed,
                 };
 
                 if (DEBUG_PAGE) console.log("   Active index set to:", activeIndex);
@@ -1879,41 +1904,18 @@ function HomeContent() {
                   startTime: new Date(),
                 };
 
-                const resource =
-                  typeof (data.input as { file_path?: string } | undefined)?.file_path === 'string'
-                    ? (data.input as { file_path: string }).file_path
-                    : typeof (data.input as { command?: string } | undefined)?.command === 'string'
-                      ? (data.input as { command: string }).command.slice(0, 80)
-                      : undefined;
-
-                const activityItem: ActivityItem = {
-                  id: `tool-${tool.id}`,
-                  kind: 'tool',
-                  timestamp: new Date(),
-                  label: tool.name,
-                  detail: resource,
-                  status: 'running',
-                  toolName: tool.name,
-                  toolId: tool.id,
-                };
-
-                // Before TodoWrite: keep tools on planningTools + activity feed
+                // Tools stay in toolsByTodo/planningTools for task view; chat
+                // feed is narrative-only and must not include tool rows.
                 if (!baseState.todos || baseState.todos.length === 0) {
                   const planningTools = [...(baseState.planningTools || [])];
                   const existingIdx = planningTools.findIndex((t) => t.id === tool.id);
                   if (existingIdx >= 0) planningTools[existingIdx] = tool;
                   else planningTools.push(tool);
 
-                  const feed = [...(baseState.activityFeed || [])];
-                  const feedIdx = feed.findIndex((item) => item.id === activityItem.id);
-                  if (feedIdx >= 0) feed[feedIdx] = { ...feed[feedIdx], ...activityItem };
-                  else feed.push(activityItem);
-
                   return {
                     ...baseState,
                     planningTools,
                     activePlanningTool: tool,
-                    activityFeed: feed.slice(-200),
                   };
                 }
 
@@ -1922,10 +1924,6 @@ function HomeContent() {
                     ? baseState.activeTodoIndex
                     : 0;
                 const existing = baseState.toolsByTodo[activeIndex] || [];
-                const feed = [...(baseState.activityFeed || [])];
-                const feedIdx = feed.findIndex((item) => item.id === activityItem.id);
-                if (feedIdx >= 0) feed[feedIdx] = { ...feed[feedIdx], ...activityItem, todoIndex: activeIndex };
-                else feed.push({ ...activityItem, todoIndex: activeIndex });
 
                 if (DEBUG_PAGE) console.log(
                   "   ✅ Nesting under todo",
@@ -1940,7 +1938,6 @@ function HomeContent() {
                     ...baseState.toolsByTodo,
                     [activeIndex]: [...existing.filter((t) => t.id !== tool.id), tool],
                   },
-                  activityFeed: feed.slice(-200),
                 };
 
                 if (DEBUG_PAGE) console.log(
@@ -3376,33 +3373,20 @@ function HomeContent() {
                                               </div>
                                             )}
 
-                                            {/* Activity feed fallback for completed builds (no todos) */}
+                                            {/* Chat feed fallback for completed builds (narrative only) */}
                                             {(!correspondingBuild.todos || correspondingBuild.todos.length === 0) &&
-                                              ((correspondingBuild.activityFeed && correspondingBuild.activityFeed.length > 0) ||
-                                                (correspondingBuild.planningTools && correspondingBuild.planningTools.length > 0)) && (
+                                              correspondingBuild.activityFeed &&
+                                              correspondingBuild.activityFeed.some(
+                                                (item) => item.kind === 'text' || item.kind === 'status'
+                                              ) && (
                                               <div className="space-y-2 rounded-xl theme-card overflow-hidden">
                                                 <p className="px-4 pt-3 text-xs uppercase tracking-[0.3em] text-gray-500">
-                                                  Activity
+                                                  Chat
                                                 </p>
                                                 <ActivityFeed
-                                                  items={
-                                                    correspondingBuild.activityFeed && correspondingBuild.activityFeed.length > 0
-                                                      ? correspondingBuild.activityFeed
-                                                      : (correspondingBuild.planningTools || []).map((tool) => ({
-                                                          id: `tool-${tool.id}`,
-                                                          kind: 'tool' as const,
-                                                          timestamp: tool.startTime || correspondingBuild.startTime,
-                                                          label: tool.name,
-                                                          status:
-                                                            tool.state === 'error'
-                                                              ? ('error' as const)
-                                                              : tool.state === 'output-available'
-                                                                ? ('completed' as const)
-                                                                : ('running' as const),
-                                                          toolName: tool.name,
-                                                          toolId: tool.id,
-                                                        }))
-                                                  }
+                                                  items={correspondingBuild.activityFeed.filter(
+                                                    (item) => item.kind === 'text' || item.kind === 'status'
+                                                  )}
                                                   isActive={false}
                                                 />
                                               </div>

--- a/apps/hatchway/src/components/BuildProgress/ActivityFeed.tsx
+++ b/apps/hatchway/src/components/BuildProgress/ActivityFeed.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { CheckCircle2, Circle, Loader2, AlertTriangle, Info } from 'lucide-react';
+import { Loader2, AlertTriangle, Info, CheckCircle2 } from 'lucide-react';
 import type { ActivityItem } from '@/types/generation';
 
 interface ActivityFeedProps {
   items: ActivityItem[];
   isActive?: boolean;
   emptyLabel?: string;
-  /** Prefer chat-style Claude lines; tools stay secondary. */
+  /** Prefer chat-style Claude lines; tools stay out of this view. */
   agentLabel?: string;
 }
 
@@ -20,23 +20,14 @@ function formatTime(ts: Date | string | number | undefined): string {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
 }
 
-function StatusIcon({ item }: { item: ActivityItem }) {
-  if (item.status === 'running') {
-    return <Loader2 className="h-3.5 w-3.5 text-theme-primary animate-spin flex-shrink-0" />;
-  }
-  if (item.status === 'error') {
-    return <AlertTriangle className="h-3.5 w-3.5 text-red-400 flex-shrink-0" />;
-  }
-  if (item.status === 'success' || item.status === 'completed') {
-    return <CheckCircle2 className="h-3.5 w-3.5 text-green-500 dark:text-green-400 flex-shrink-0" />;
-  }
-  if (item.status === 'warning') {
-    return <AlertTriangle className="h-3.5 w-3.5 text-amber-400 flex-shrink-0" />;
-  }
+/** Chat panel shows Claude narrative + important status only — never tool rows. */
+function isChatVisible(item: ActivityItem): boolean {
+  if (item.kind === 'text') return Boolean(item.label?.trim());
   if (item.kind === 'status') {
-    return <Info className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />;
+    // Keep progress/error status; drop noisy "Build started" style noise if empty
+    return Boolean(item.label?.trim());
   }
-  return <Circle className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />;
+  return false;
 }
 
 export function ActivityFeed({
@@ -47,6 +38,8 @@ export function ActivityFeed({
 }: ActivityFeedProps) {
   const scrollerRef = useRef<HTMLDivElement>(null);
   const stickToBottomRef = useRef(true);
+
+  const chatItems = useMemo(() => items.filter(isChatVisible), [items]);
 
   useEffect(() => {
     const el = scrollerRef.current;
@@ -63,13 +56,20 @@ export function ActivityFeed({
     const el = scrollerRef.current;
     if (!el || !stickToBottomRef.current) return;
     el.scrollTop = el.scrollHeight;
-  }, [items.length, items[items.length - 1]?.id, items[items.length - 1]?.label, items[items.length - 1]?.status]);
+  }, [
+    chatItems.length,
+    chatItems[chatItems.length - 1]?.id,
+    chatItems[chatItems.length - 1]?.label,
+    chatItems[chatItems.length - 1]?.status,
+  ]);
 
-  if (!items.length) {
+  if (!chatItems.length) {
     return (
       <div className="px-4 py-6 text-sm text-muted-foreground flex items-center gap-2">
         {isActive ? <Loader2 className="h-4 w-4 animate-spin text-theme-primary" /> : null}
-        <span className={isActive ? 'shimmer-text' : ''}>{emptyLabel}</span>
+        <span className={isActive ? 'shimmer-text' : ''}>
+          {isActive ? `${agentLabel} is working…` : emptyLabel}
+        </span>
       </div>
     );
   }
@@ -77,17 +77,17 @@ export function ActivityFeed({
   return (
     <div
       ref={scrollerRef}
-      className="max-h-[420px] overflow-y-auto px-3 py-3 space-y-1.5"
+      className="max-h-[420px] overflow-y-auto px-3 py-3 space-y-2"
     >
       <AnimatePresence initial={false}>
-        {items.map((item) => {
+        {chatItems.map((item) => {
           if (item.kind === 'text') {
             return (
               <motion.div
                 key={item.id}
                 initial={{ opacity: 0, y: 4 }}
                 animate={{ opacity: 1, y: 0 }}
-                className="rounded-lg px-2.5 py-2 bg-theme-primary/5 border border-theme-primary/10"
+                className="rounded-lg px-3 py-2.5 bg-theme-primary/5 border border-theme-primary/10"
               >
                 <div className="flex items-baseline justify-between gap-2 mb-1">
                   <span className="text-[11px] font-semibold tracking-wide text-theme-primary">
@@ -104,50 +104,39 @@ export function ActivityFeed({
             );
           }
 
+          // status rows
           const isError = item.status === 'error';
-          const isRunning = item.status === 'running';
-          const isTool = item.kind === 'tool';
-
+          const isSuccess = item.status === 'success' || item.status === 'completed';
+          const isWarning = item.status === 'warning';
           return (
             <motion.div
               key={item.id}
               initial={{ opacity: 0, y: 4 }}
               animate={{ opacity: 1, y: 0 }}
-              className={`flex items-start gap-2 py-1 px-1.5 rounded font-mono text-[11px] leading-relaxed ${
+              className={`flex items-start gap-2 rounded-md px-2.5 py-1.5 text-xs ${
                 isError
-                  ? 'bg-red-500/5 text-red-300'
-                  : isRunning
-                    ? 'bg-theme-primary/5'
-                    : 'text-muted-foreground'
+                  ? 'bg-red-500/10 text-red-200'
+                  : isWarning
+                    ? 'bg-amber-500/10 text-amber-100'
+                    : isSuccess
+                      ? 'bg-green-500/10 text-green-200'
+                      : 'bg-white/5 text-muted-foreground'
               }`}
             >
-              <StatusIcon item={item} />
+              {isError ? (
+                <AlertTriangle className="h-3.5 w-3.5 mt-0.5 flex-shrink-0" />
+              ) : isSuccess ? (
+                <CheckCircle2 className="h-3.5 w-3.5 mt-0.5 flex-shrink-0" />
+              ) : (
+                <Info className="h-3.5 w-3.5 mt-0.5 flex-shrink-0" />
+              )}
               <div className="min-w-0 flex-1">
-                <div className="flex items-baseline gap-2 min-w-0">
-                  <span
-                    className={`truncate ${
-                      isTool
-                        ? isRunning
-                          ? 'shimmer-text text-foreground/80'
-                          : 'text-foreground/70'
-                        : item.kind === 'todo'
-                          ? 'text-foreground/90 font-medium'
-                          : isError
-                            ? 'text-red-300'
-                            : 'text-foreground/70'
-                    }`}
-                  >
-                    {isTool ? `› ${item.label}` : item.label}
-                  </span>
-                  {item.detail && item.kind !== 'status' && (
-                    <span className="truncate text-muted-foreground/70">{item.detail}</span>
-                  )}
-                </div>
-                {item.kind === 'status' && item.detail && (
-                  <div className="text-[10px] text-muted-foreground/70 mt-0.5">{item.detail}</div>
-                )}
+                <p className="leading-relaxed break-words">{item.label}</p>
+                {item.detail ? (
+                  <p className="text-[10px] opacity-70 mt-0.5">{item.detail}</p>
+                ) : null}
               </div>
-              <span className="text-[10px] text-muted-foreground/40 flex-shrink-0 tabular-nums pt-0.5">
+              <span className="text-[10px] opacity-50 flex-shrink-0 tabular-nums">
                 {formatTime(item.timestamp)}
               </span>
             </motion.div>
@@ -155,7 +144,7 @@ export function ActivityFeed({
         })}
       </AnimatePresence>
       {isActive && (
-        <div className="flex items-center gap-2 py-1.5 px-1.5 text-muted-foreground font-mono text-[11px]">
+        <div className="flex items-center gap-2 py-1.5 px-1 text-muted-foreground text-xs">
           <Loader2 className="h-3.5 w-3.5 animate-spin text-theme-primary" />
           <span className="shimmer-text">{agentLabel} is working…</span>
         </div>

--- a/apps/hatchway/src/components/BuildProgress/index.tsx
+++ b/apps/hatchway/src/components/BuildProgress/index.tsx
@@ -3,7 +3,7 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import { Loader2, CheckCircle2, ChevronDown, ChevronUp, Square, AlertTriangle } from 'lucide-react';
 import { useState, useEffect, useMemo, useRef } from 'react';
-import type { GenerationState, TodoItem, ActivityItem, ToolCall } from '@/types/generation';
+import type { GenerationState, TodoItem, ActivityItem } from '@/types/generation';
 import { BuildHeader } from './BuildHeader';
 import { TodoList } from './TodoList';
 import { PlanningPhase } from './PlanningPhase';
@@ -24,57 +24,15 @@ interface BuildProgressProps {
   } | null;
 }
 
-function getToolResource(tool: ToolCall): string {
-  if (!tool.input) return '';
-  const input = tool.input as Record<string, unknown>;
-  if (typeof input.skillName === 'string') return input.skillName;
-  if (typeof input.file_path === 'string') {
-    const path = input.file_path;
-    const match = path.match(/hatchway-workspace\/[^/]+\/(.+)$/);
-    return match ? match[1] : path.split('/').slice(-2).join('/');
-  }
-  if (typeof input.path === 'string') {
-    const path = input.path;
-    const match = path.match(/hatchway-workspace\/[^/]+\/(.+)$/);
-    return match ? match[1] : path.split('/').slice(-2).join('/');
-  }
-  if (typeof input.command === 'string') {
-    return input.command.length > 80 ? `${input.command.slice(0, 80)}…` : input.command;
-  }
-  if (typeof input.query === 'string') {
-    return input.query.length > 80 ? `${input.query.slice(0, 80)}…` : input.query;
-  }
-  if (typeof input.pattern === 'string') return input.pattern;
-  return '';
-}
-
-/** Reconstruct a chronological feed when live activityFeed is empty (reconnect / history). */
+/** Reconstruct a chronological chat feed when live activityFeed is empty (reconnect / history).
+ * Chat is narrative-only: Claude text + high-level status. Tools never appear here.
+ */
 function deriveActivityFeed(state: GenerationState): ActivityItem[] {
   if (state.activityFeed && state.activityFeed.length > 0) {
-    return state.activityFeed;
+    return state.activityFeed.filter((item) => item.kind === 'text' || item.kind === 'status');
   }
 
   const items: ActivityItem[] = [];
-
-  for (const tool of state.planningTools || []) {
-    if (tool.name === 'TodoWrite') continue;
-    items.push({
-      id: `tool-${tool.id}`,
-      kind: 'tool',
-      timestamp: tool.startTime || state.startTime,
-      label: tool.name,
-      detail: getToolResource(tool),
-      status:
-        tool.state === 'error'
-          ? 'error'
-          : tool.state === 'output-available'
-            ? 'completed'
-            : 'running',
-      toolName: tool.name,
-      toolId: tool.id,
-      todoIndex: -1,
-    });
-  }
 
   // Narrative text keyed by todo index (including 0 before todos exist)
   const textEntries = Object.entries(state.textByTodo || {})
@@ -94,44 +52,30 @@ function deriveActivityFeed(state: GenerationState): ActivityItem[] {
     });
   }
 
-  (state.todos || []).forEach((todo, index) => {
-    if (todo.status === 'pending') return;
-    items.push({
-      id: `todo-derived-${index}`,
-      kind: 'todo',
-      timestamp: state.startTime,
-      label: todo.status === 'in_progress' ? todo.activeForm : todo.content,
-      status: todo.status === 'completed' ? 'completed' : 'running',
-      todoIndex: index,
-    });
-
-    for (const tool of state.toolsByTodo?.[index] || []) {
-      if (tool.name === 'TodoWrite') continue;
+  // Surface the active todo form as a lightweight Claude status line when we
+  // have no narrative yet (Claude Code often works silently via tools).
+  const activeIdx = state.activeTodoIndex ?? -1;
+  const activeTodo = activeIdx >= 0 ? state.todos?.[activeIdx] : undefined;
+  if (activeTodo && (activeTodo.status === 'in_progress' || activeTodo.status === 'completed')) {
+    const label = (activeTodo.status === 'in_progress' ? activeTodo.activeForm : activeTodo.content) || activeTodo.content;
+    if (label?.trim()) {
       items.push({
-        id: `tool-${tool.id}`,
-        kind: 'tool',
-        timestamp: tool.startTime || state.startTime,
-        label: tool.name,
-        detail: getToolResource(tool),
-        status:
-          tool.state === 'error'
-            ? 'error'
-            : tool.state === 'output-available'
-              ? 'completed'
-              : 'running',
-        toolName: tool.name,
-        toolId: tool.id,
-        todoIndex: index,
+        id: `text-todo-status-${activeIdx}-${label.slice(0, 40)}`,
+        kind: 'text',
+        timestamp: state.startTime,
+        label,
+        status: 'info',
+        todoIndex: activeIdx,
       });
     }
-  });
+  }
 
   if (state.buildSummary) {
     items.push({
       id: 'text-summary-derived',
       kind: 'text',
       timestamp: state.endTime || new Date(),
-      label: state.buildSummary.slice(0, 200),
+      label: state.buildSummary.slice(0, 400),
       status: 'info',
     });
   }

--- a/apps/hatchway/src/hooks/useBuildWebSocket.ts
+++ b/apps/hatchway/src/hooks/useBuildWebSocket.ts
@@ -418,15 +418,22 @@ export function useBuildWebSocket({
               mappedTodos[todosData.activeTodoIndex] ||
               mappedTodos.find((t) => t.status === 'in_progress');
             if (activeTodo) {
-              newState.activityFeed = upsertActivityItem(newState.activityFeed, {
-                id: `todo-${todosData.phase || 'build'}-${todosData.activeTodoIndex}-${activeTodo.content.slice(0, 40)}`,
-                kind: 'todo',
-                timestamp: new Date(),
-                label: activeTodo.status === 'in_progress' ? activeTodo.activeForm : activeTodo.content,
-                detail: todosData.phase === 'template' ? 'template' : 'build',
-                status: activeTodo.status === 'completed' ? 'completed' : 'running',
-                todoIndex: todosData.activeTodoIndex,
-              });
+              // Surface the active task form as a Claude status line (chat is
+              // narrative-only; tools never appear in the feed).
+              const label =
+                (activeTodo.status === 'in_progress'
+                  ? activeTodo.activeForm || activeTodo.content
+                  : activeTodo.content) || activeTodo.content;
+              if (label?.trim()) {
+                newState.activityFeed = upsertActivityItem(newState.activityFeed, {
+                  id: `text-todo-${todosData.phase || 'build'}-${todosData.activeTodoIndex}-${label.slice(0, 48)}`,
+                  kind: 'text',
+                  timestamp: new Date(),
+                  label,
+                  status: 'info',
+                  todoIndex: todosData.activeTodoIndex,
+                });
+              }
             }
             break;
 
@@ -588,25 +595,8 @@ export function useBuildWebSocket({
               }
             }
 
-            if (toolData.name !== 'TodoWrite') {
-              const activityStatus =
-                toolData.state === 'error'
-                  ? 'error'
-                  : toolData.state === 'output-available'
-                    ? 'completed'
-                    : 'running';
-              newState.activityFeed = upsertActivityItem(newState.activityFeed, {
-                id: `tool-${toolData.id}`,
-                kind: 'tool',
-                timestamp: new Date(update.timestamp || Date.now()),
-                label: toolData.name,
-                detail: getToolResourceLabel(toolCall),
-                status: activityStatus,
-                toolName: toolData.name,
-                toolId: toolData.id,
-                todoIndex: toolData.todoIndex,
-              });
-            }
+            // Intentionally do NOT push tools into activityFeed — chat is
+            // narrative-only (Claude text + status). Tools remain in toolsByTodo.
             break;
         }
       }


### PR DESCRIPTION
## Summary
- Chat panel filters to `text` + `status` only (no Read/Bash/Write tool rows)
- Stop pushing tool calls into `activityFeed` from SSE and WebSocket paths
- Surface TodoWrite `activeForm` as Claude status lines so the feed is not empty when Claude works via tools
- Completed-build fallback no longer falls back to planning tool dumps

## Test plan
- [ ] Start a build and confirm left chat shows Claude lines / task status, not `› Read` / `› Bash`
- [ ] Confirm preview/status errors still appear
- [ ] Tasks toggle still shows tools under todos if needed